### PR TITLE
Add KafkaDirectInput to inputs docs

### DIFF
--- a/doc/src/site/sphinx/inputs.rst
+++ b/doc/src/site/sphinx/inputs.rst
@@ -59,6 +59,21 @@ Reads events from apache-kafka
         }
     ]
 
+* DirectInput Sample:
+::
+
+    "inputs": [
+        {
+            "name": "in",
+            "elementType": "KafkaDirectInput",
+            "configuration": {
+                "topics": "topic1",
+                "kafkaParams.metadata.broker.list": "localhost:9092",
+                "kafkaParams.group.id" : "kafka-test",
+            }
+        }
+    ]
+
 .. _rabbitMQ-label:
 
 Input-rabbitMQ


### PR DESCRIPTION
KafkaDirectInput is missing from docs but is supported. Add this input doc.