### PR TITLE
Feature/output cassandra fulltext

### DIFF
--- a/doc/src/site/sphinx/outputs.rst
+++ b/doc/src/site/sphinx/outputs.rst
@@ -79,6 +79,14 @@ These parameters can be completed in the policy file:
 
    "isAutoCalculateId": ("true"/"false")  Default: "false"
 
+* fixedAggregation:
+   It's possible to specify one fixed aggregation with value for all dimensions.
+   You can omit this parameter in the policy.
+
+   * Example:
+::
+
+   "fixedAggregation": ("NAME:VALUE")  Default: None
 
 .. _mongodb-label:
 
@@ -260,7 +268,9 @@ For more information for this output you can visit the :doc:`cassandra`
    * Example:
 ::
 
-   "textIndexFields": ("bucket1,bucket2,bucket3,aggregate1, aggregate2, ...")  Default: ""
+   "textIndexFields": ("bucket1:type,bucket2:type,bucket3:type,aggregate1:type, aggregate2:type, ...")  Default: ""
+
+      type: "string/text/date/integer/long/double/...."
 
 * analyzer:
    It's possible to specify the analyzer for text index fields, this feature is for the Stratio Cassandra.
@@ -271,14 +281,34 @@ For more information for this output you can visit the :doc:`cassandra`
 
    "analyzer": ("english"/"spanish"...)  Default: None
 
-* textIndexName:
+* textIndexFieldsName:
    It's possible to specify the name of the text index, this feature is for the Stratio Cassandra.
    You can omit this parameter in the policy.
 
    * Example:
 ::
 
-   "textIndexName": ("NAME")  Default: "lucene"
+   "textIndexFieldsName": ("NAME")  Default: "lucene"
+
+* refreshSeconds:
+   It's possible to specify the number of seconds between refresh lucene index operations, this feature is for the
+   Stratio Cassandra.
+   You can omit this parameter in the policy.
+
+   * Example:
+::
+
+   "refreshSeconds": ("NUMBER")  Default: "1"
+
+* dateFormat:
+   It's possible to specify the date format for the date fields indexed, this feature is for the
+   Stratio Cassandra.
+   You can omit this parameter in the policy.
+
+   * Example:
+::
+
+   "dateFormat": ("SimpleDateFormat")  Default: "yyyy/mm/dd"
 
 
 .. _elasticsearch-label:

--- a/doc/src/site/sphinx/usingSparkta.rst
+++ b/doc/src/site/sphinx/usingSparkta.rst
@@ -48,6 +48,7 @@ An aggregation policy it's a JSON document. It's composed of:
 * :ref:`RollUp(s) <rollup>`: How do you want to aggregate the dimensions?
 * :ref:`Transformation(s) <transformation>`: Which functions should be applied before aggregation?
 * :ref:`Save raw data <save-raw>`: Do you want to save raw events?
+* :ref:`Define stateful operations <stateful>`: Do you want to make non associative aggregations?
 
 The policy have a few required fields like *name* and *duration* and others optional, like *saveRawData*, *rawDataParquetPath* and *rawDataGranularity*
 
@@ -236,6 +237,8 @@ You can save the raw data to HDFS+Parquet with only two parameters:
     "saveRawData": "false",
     "rawDataParquetPath": "myTestParquetPath"
     "rawDataGranularity": "day"
+
+.. _stateful:
 
 Stateful Operations
 -------------------

--- a/driver/src/main/scala/com/stratio/sparkta/driver/service/StreamingContextService.scala
+++ b/driver/src/main/scala/com/stratio/sparkta/driver/service/StreamingContextService.scala
@@ -68,7 +68,7 @@ class StreamingContextService(generalConfig: Config, jars: Seq[File]) extends SL
       )))
 
     val bcRollupOperatorSchema: Option[Broadcast[Seq[TableSchema]]] = {
-      val rollOpSchema = PolicyFactory.rollupsOperatorsSchemas(rollups, outputsSchemaConfig, operators)
+      val rollOpSchema = PolicyFactory.rollupsOperatorsSchemas(rollups, outputsSchemaConfig)
       if (rollOpSchema.size > 0) Some(sc.broadcast(rollOpSchema)) else None
     }
     val dateBucket = if (apConfig.timeBucket.isEmpty) None else Some(apConfig.timeBucket)

--- a/driver/src/main/scala/com/stratio/sparkta/driver/service/StreamingContextService.scala
+++ b/driver/src/main/scala/com/stratio/sparkta/driver/service/StreamingContextService.scala
@@ -59,11 +59,16 @@ class StreamingContextService(generalConfig: Config, jars: Seq[File]) extends SL
       if (opKeyOp.size > 0) Some(sc.broadcast(opKeyOp)) else None
     }
 
-    val outputsConfig: Seq[(String, Boolean)] = apConfig.outputs.map(o =>
-      (o.name, Try(o.configuration.get("multiplexer").get.string.toBoolean).getOrElse(false)))
+    val outputsSchemaConfig: Seq[(String, Map[String, String])] = apConfig.outputs.map(o =>
+      (o.name, Map(
+        Output.Multiplexer -> Try(o.configuration.get(Output.Multiplexer).get.string).getOrElse("false"),
+        Output.FixedAggregation ->
+          Try(o.configuration.get(Output.FixedAggregation).get.string.split(Output.FixedAggregationSeparator).head)
+          .getOrElse("")
+      )))
 
     val bcRollupOperatorSchema: Option[Broadcast[Seq[TableSchema]]] = {
-      val rollOpSchema = PolicyFactory.rollupsOperatorsSchemas(rollups, outputsConfig, operators)
+      val rollOpSchema = PolicyFactory.rollupsOperatorsSchemas(rollups, outputsSchemaConfig, operators)
       if (rollOpSchema.size > 0) Some(sc.broadcast(rollOpSchema)) else None
     }
     val dateBucket = if (apConfig.timeBucket.isEmpty) None else Some(apConfig.timeBucket)

--- a/driver/src/test/scala/com/stratio/sparkta/driver/test/service/RawDataStorageIT.scala
+++ b/driver/src/test/scala/com/stratio/sparkta/driver/test/service/RawDataStorageIT.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.stratio.sparkta.driver.test.service
 
 import java.io.File

--- a/examples/policies/ITwitter-OCassandra.json
+++ b/examples/policies/ITwitter-OCassandra.json
@@ -77,12 +77,14 @@
         "class": "SimpleStrategy",
         "replicationFactor": "1",
         "multiplexer": "false",
-        "isAutoCalculateId" : "false",
+        "isAutoCalculateId": "false",
         "clusteringBuckets": "",
         "indexFields": "minute",
-        "textIndexFields": "userLocation",
+        "textIndexFields": "userLocation:text,minute:date,sum_wordsN:integer",
         "fieldsSeparator": ",",
         "textIndexFieldsName": "lucene",
+        "refreshSeconds": "1",
+        "dateFormat": "yyyy/MM/dd",
         "analyzer": "english"
       }
     }

--- a/examples/policies/ITwitter-OCassandra.json
+++ b/examples/policies/ITwitter-OCassandra.json
@@ -63,7 +63,7 @@
         }
       ],
       "operators": ["count-operator","sum-operator","max-operator","min-operator","avg-operator","median-operator",
-        "variance-operator","stddev-operator","fullText-operator","lastValue-operator","accumulator-operator"]
+        "variance-operator","stddev-operator","fullText-operator","lastValue-operator"]
     }
   ],
   "outputs": [

--- a/examples/policies/ITwitter-OCassandra.json
+++ b/examples/policies/ITwitter-OCassandra.json
@@ -80,9 +80,10 @@
         "isAutoCalculateId": "false",
         "clusteringBuckets": "",
         "indexFields": "minute",
-        "textIndexFields": "userLocation:text,minute:date,sum_wordsN:integer",
+        "textIndexFields": "firsthastag:string,userLocation:text,minute:date,avg_wordsn:double,count:long",
         "fieldsSeparator": ",",
         "textIndexFieldsName": "lucene",
+        "fixedAggregation": "lucene",
         "refreshSeconds": "1",
         "dateFormat": "yyyy/MM/dd",
         "analyzer": "english"
@@ -94,13 +95,6 @@
       "name": "count-operator",
       "elementType": "CountOperator",
       "configuration": {}
-    },
-    {
-      "name": "sum-operator",
-      "elementType": "SumOperator",
-      "configuration": {
-        "inputField": "wordsN"
-      }
     },
     {
       "name": "max-operator",
@@ -156,13 +150,6 @@
       "elementType": "LastValueOperator",
       "configuration": {
         "inputField": "retweets"
-      }
-    },
-    {
-      "name": "accumulator-operator",
-      "elementType": "AccumulatorOperator",
-      "configuration": {
-        "inputField": "wordsN"
       }
     }
   ]

--- a/plugins/output-cassandra/src/main/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraOutput.scala
+++ b/plugins/output-cassandra/src/main/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraOutput.scala
@@ -19,6 +19,7 @@ package com.stratio.sparkta.plugin.output.cassandra
 import java.io.{Serializable => JSerializable}
 import scala.util.Try
 
+import com.datastax.spark.connector.cql.CassandraConnector
 import org.apache.spark.SparkContext
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.SaveMode._
@@ -41,7 +42,7 @@ class CassandraOutput(keyName: String,
   with CassandraDAO {
 
   override val supportedWriteOps = Seq(WriteOp.Inc, WriteOp.IncBig, WriteOp.Set, WriteOp.Max, WriteOp.Min,
-    WriteOp.AccAvg, WriteOp.AccMedian, WriteOp.AccVariance, WriteOp.AccStddev, WriteOp.FullText, WriteOp.AccSet)
+    WriteOp.AccAvg, WriteOp.AccMedian, WriteOp.AccVariance, WriteOp.AccStddev, WriteOp.FullText)
 
   override val multiplexer = Try(properties.getString("multiplexer").toBoolean).getOrElse(false)
 
@@ -78,11 +79,20 @@ class CassandraOutput(keyName: String,
 
   override val textIndexName = properties.getString("textIndexName", "lucene")
 
-  override val connector = configConnector(sparkContext.getConf)
+  val fixedAgg = properties.getString("fixedAggregation", None)
+
+  override val fixedAggregation: Map[String, Option[Any]] =
+    if(!textIndexFields.isEmpty && fixedAgg.isDefined){
+      val fixedAggSplited = fixedAgg.get.split(Output.FixedAggregationSeparator)
+      Map(fixedAggSplited.head -> Some(""))
+    } else Map()
+
+  override val connector = Some(CassandraConnector(sparkContext.getConf))
 
   val keyspaceCreated = createKeypace
 
-  val schemaFiltered = filterSchemaByKeyAndField
+  val schemaFiltered = bcSchema.get.value.filter(tschema => (tschema.outputName == keyName))
+    .map(tschemaFiltered => getTableSchemaFixedId(tschemaFiltered))
 
   val tablesCreated = if (keyspaceCreated) {
     bcSchema.exists(bc => createTables(schemaFiltered, timeName, isAutoCalculateId))
@@ -92,7 +102,11 @@ class CassandraOutput(keyName: String,
     bcSchema.exists(bc => createIndexes(schemaFiltered, timeName, isAutoCalculateId))
   } else false
 
-  val textIndexesCreated = if (keyspaceCreated && tablesCreated) {
+  val textIndexesCreated = if (keyspaceCreated &&
+    tablesCreated &&
+    !textIndexFields.isEmpty &&
+    !fixedAggregation.isEmpty &&
+    fixedAgg.get == textIndexName) {
     bcSchema.exists(bc => createTextIndexes(schemaFiltered))
   } else false
 
@@ -111,8 +125,11 @@ class CassandraOutput(keyName: String,
 }
 
 object CassandraOutput {
+
+  final val DefaultHost = "127.0.0.1"
+
   def getSparkConfiguration(configuration : Map[String, JSerializable]) : Seq[(String, String)] = {
-    val connectionHost = configuration.getString("connectionHost", "127.0.0.1")
+    val connectionHost = configuration.getString("connectionHost", DefaultHost)
     Seq(("spark.cassandra.connection.host", connectionHost))
   }
 }

--- a/plugins/output-cassandra/src/main/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraOutput.scala
+++ b/plugins/output-cassandra/src/main/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraOutput.scala
@@ -70,7 +70,11 @@ class CassandraOutput(keyName: String,
 
   override val textIndexFields = properties.getString("textIndexFields", "").split(fieldsSeparator)
 
-  override val analyzer = properties.getString("analyzer", None)
+  override val analyzer = properties.getString("analyzer", DefaultAnalyzer)
+
+  override val dateFormat = properties.getString("dateFormat", DefaultDateFormat)
+
+  override val refreshSeconds = properties.getString("refreshSeconds", DefaultRefreshSeconds)
 
   override val textIndexName = properties.getString("textIndexName", "lucene")
 
@@ -86,6 +90,10 @@ class CassandraOutput(keyName: String,
 
   val indexesCreated = if (keyspaceCreated && tablesCreated) {
     bcSchema.exists(bc => createIndexes(schemaFiltered, timeName, isAutoCalculateId))
+  } else false
+
+  val textIndexesCreated = if (keyspaceCreated && tablesCreated) {
+    bcSchema.exists(bc => createTextIndexes(schemaFiltered))
   } else false
 
   /*

--- a/plugins/output-cassandra/src/main/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraOutput.scala
+++ b/plugins/output-cassandra/src/main/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraOutput.scala
@@ -82,7 +82,7 @@ class CassandraOutput(keyName: String,
   val fixedAgg = properties.getString("fixedAggregation", None)
 
   override val fixedAggregation: Map[String, Option[Any]] =
-    if(!textIndexFields.isEmpty && fixedAgg.isDefined){
+    if (!textIndexFields.isEmpty && fixedAgg.isDefined) {
       val fixedAggSplited = fixedAgg.get.split(Output.FixedAggregationSeparator)
       Map(fixedAggSplited.head -> Some(""))
     } else Map()
@@ -128,7 +128,7 @@ object CassandraOutput {
 
   final val DefaultHost = "127.0.0.1"
 
-  def getSparkConfiguration(configuration : Map[String, JSerializable]) : Seq[(String, String)] = {
+  def getSparkConfiguration(configuration: Map[String, JSerializable]): Seq[(String, String)] = {
     val connectionHost = configuration.getString("connectionHost", DefaultHost)
     Seq(("spark.cassandra.connection.host", connectionHost))
   }

--- a/plugins/output-cassandra/src/main/scala/com/stratio/sparkta/plugin/output/cassandra/dao/CassandraDAO.scala
+++ b/plugins/output-cassandra/src/main/scala/com/stratio/sparkta/plugin/output/cassandra/dao/CassandraDAO.scala
@@ -137,7 +137,7 @@ trait CassandraDAO extends Closeable with Logging {
     seqResults.forall(result => result)
   }
 
-  protected def getTextIndexSentence(fields : Array[String]) : String = {
+  protected def getTextIndexSentence(fields: Array[String]): String = {
     val fieldsSentence = fields.map(field => {
       val fieldDescompose = field.split(":")
       val endSentence = fieldDescompose.last match {

--- a/plugins/output-elasticsearch/src/main/scala/com/stratio/sparkta/plugin/output/elasticsearch/ElasticSearchOutput.scala
+++ b/plugins/output-elasticsearch/src/main/scala/com/stratio/sparkta/plugin/output/elasticsearch/ElasticSearchOutput.scala
@@ -62,6 +62,14 @@ class ElasticSearchOutput(keyName: String,
 
   override val isAutoCalculateId = Try(properties.getString("isAutoCalculateId").toBoolean).getOrElse(false)
 
+  val fixedAgg = properties.getString("fixedAggregation", None)
+
+  override val fixedAggregation: Map[String, Option[Any]] =
+    if(fixedAgg.isDefined){
+      val fixedAggSplited = fixedAgg.get.split(Output.FixedAggregationSeparator)
+      Map(fixedAggSplited.head -> Some(fixedAggSplited.last))
+    } else Map()
+
   override val idField = properties.getString("idField", None)
 
   override val defaultIndexMapping = properties.getString("indexMapping",

--- a/plugins/output-elasticsearch/src/main/scala/com/stratio/sparkta/plugin/output/elasticsearch/dao/ElasticSearchDAO.scala
+++ b/plugins/output-elasticsearch/src/main/scala/com/stratio/sparkta/plugin/output/elasticsearch/dao/ElasticSearchDAO.scala
@@ -54,7 +54,7 @@ trait ElasticSearchDAO extends Closeable {
 
   def getSparkConfig(timeName: String, idProvided: Boolean): Map[String, String] = {
     {
-      if (idProvided) Map("es.mapping.id" -> idField.getOrElse(Output.ID)) else Map("" -> "")
+      if (idProvided) Map("es.mapping.id" -> idField.getOrElse(Output.Id)) else Map("" -> "")
     } ++
       Map("es.nodes" -> nodes, "es.port" -> defaultPort) ++ {
       defaultAnalyzerType match {

--- a/plugins/output-mongodb/src/main/scala/com/stratio/sparkta/plugin/output/mongodb/MongoDbOutput.scala
+++ b/plugins/output-mongodb/src/main/scala/com/stratio/sparkta/plugin/output/mongodb/MongoDbOutput.scala
@@ -81,7 +81,7 @@ class MongoDbOutput(keyName: String,
     metricOperations.toList.groupBy(upMetricOp => AggregateOperations.keyString(upMetricOp._1))
       .filter(_._1.size > 0).foreach(f = collMetricOp => {
       val bulkOperation = db().getCollection(collMetricOp._1).initializeOrderedBulkOperation()
-      val idFieldName = if (!timeName.isEmpty) Output.ID else DefaultId
+      val idFieldName = if (!timeName.isEmpty) Output.Id else DefaultId
 
       val updateObjects = collMetricOp._2.map { case (rollupKey, aggregations) => {
         checkFields(aggregations.keySet, operationTypes)

--- a/plugins/output-mongodb/src/main/scala/com/stratio/sparkta/plugin/output/mongodb/dao/MongoDbDAO.scala
+++ b/plugins/output-mongodb/src/main/scala/com/stratio/sparkta/plugin/output/mongodb/dao/MongoDbDAO.scala
@@ -76,10 +76,10 @@ trait MongoDbDAO extends Closeable {
     val textIndexCreated = textIndexFields.size > 0
 
     if (textIndexCreated)
-      createTextIndex(collection, textIndexFields.mkString(Output.SEPARATOR), textIndexFields, language)
+      createTextIndex(collection, textIndexFields.mkString(Output.Separator), textIndexFields, language)
     if (!timeBucket.isEmpty) {
-      createIndex(collection, Output.ID + Output.SEPARATOR + timeBucket,
-        Map(Output.ID -> 1, timeBucket -> 1), true, true)
+      createIndex(collection, Output.Id + Output.Separator + timeBucket,
+        Map(Output.Id -> 1, timeBucket -> 1), true, true)
     }
     (!timeBucket.isEmpty, textIndexCreated)
   }
@@ -140,7 +140,7 @@ trait MongoDbDAO extends Closeable {
                         dimensionValues: Seq[DimensionValue]): Imports.DBObject = {
     val builder = MongoDBObject.newBuilder
     builder += idFieldName -> dimensionValues.map(dimVal => dimVal.value.toString)
-      .mkString(Output.SEPARATOR)
+      .mkString(Output.Separator)
     if (eventTimeObject.isDefined) builder += eventTimeObject.get
     builder.result
   }

--- a/plugins/output-print/src/main/scala/com/stratio/sparkta/plugin/output/print/PrintOutput.scala
+++ b/plugins/output-print/src/main/scala/com/stratio/sparkta/plugin/output/print/PrintOutput.scala
@@ -56,6 +56,14 @@ class PrintOutput(keyName: String,
     case Some(fixBuckets) => fixBuckets.split(fieldsSeparator)
   }
 
+  val fixedAgg = properties.getString("fixedAggregation", None)
+
+  override val fixedAggregation: Map[String, Option[Any]] =
+    if(fixedAgg.isDefined){
+      val fixedAggSplited = fixedAgg.get.split(Output.FixedAggregationSeparator)
+      Map(fixedAggSplited.head -> Some(fixedAggSplited.last))
+    } else Map()
+
   override val isAutoCalculateId = Try(properties.getString("isAutoCalculateId").toBoolean).getOrElse(false)
 
   override def upsert(dataFrame: DataFrame, tableName: String): Unit = {

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/AggregateOperations.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/AggregateOperations.scala
@@ -50,12 +50,13 @@ object AggregateOperations {
         .sortWith((bucket1, bucket2) => bucket1._1 < bucket2._1)
       (namesDim ++ fixedBucketsSorted.map(_._1) ++ Seq(timeName),
         valuesDim ++ fixedBucketsSorted.map(_._2) ++
-          Seq(DateOperations.millisToTimeStamp(dimensionValuesT.time)) ++ valuesAgg)
+          Seq(DateOperations.millisToTimeStamp(dimensionValuesT.time)))
     } else (namesDim ++ Seq(timeName),
-      valuesDim ++ Seq(DateOperations.millisToTimeStamp(dimensionValuesT.time)) ++ valuesAgg)
-    val (keys, row) = getNamesValues(namesFixed, valuesFixed, idCalculated)
+      valuesDim ++ Seq(DateOperations.millisToTimeStamp(dimensionValuesT.time)))
+    val (keysId, rowId) = getNamesValues(namesFixed, valuesFixed, idCalculated)
 
-    if (keys.length > 0) (Some(keys.mkString(Output.Separator)), Row.fromSeq(row)) else (None, Row.fromSeq(row))
+    if (keysId.length > 0) (Some(keysId.mkString(Output.Separator)), Row.fromSeq(rowId ++ valuesAgg))
+    else (None, Row.fromSeq(rowId ++ valuesAgg))
   }
 
   def toSeq(dimensionValues: Seq[DimensionValue], aggregations: Map[String, Option[Any]]): (Seq[Any], Seq[Any]) =

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/Multiplexer.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/Multiplexer.scala
@@ -31,7 +31,7 @@ trait Multiplexer {
 
 object Multiplexer {
 
-  def combine[T](in: (Seq[T], Long)): Seq[(Seq[T], Long)] = {
+  def combine[T, U](in: (Seq[T], U)): Seq[(Seq[T], U)] = {
     for {
       len <- 1 to in._1.length
       combinations <- in._1 combinations len

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/Output.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/Output.scala
@@ -54,6 +54,8 @@ abstract class Output(keyName: String,
 
   def fixedBuckets: Array[String] = Array()
 
+  def fixedAggregation: Map[String, Option[Any]] = Map()
+
   def fieldsSeparator: String = ","
 
   def isAutoCalculateId: Boolean = false
@@ -77,6 +79,7 @@ abstract class Output(keyName: String,
       .map { case (dimensionValueTime, aggregations) =>
       AggregateOperations.toKeyRow(filterDimensionValueTimeByFixedBuckets(dimensionValueTime),
         aggregations,
+        fixedAggregation,
         getFixedBuckets(dimensionValueTime),
         isAutoCalculateId,
         timeName)
@@ -108,37 +111,44 @@ abstract class Output(keyName: String,
     }
 
   protected def getTableSchemaFixedId(tbSchema: TableSchema): TableSchema = {
-    var tableName = tbSchema.tableName.split(Output.SEPARATOR)
-      .filter(name => !fixedBuckets.contains(name) && name != timeName).mkString(Output.SEPARATOR)
-    var fields = tbSchema.schema.fields.toSeq.filter(field =>
-      !fixedBuckets.contains(field.name) && field.name != timeName)
+    var tableName = tbSchema.tableName.split(Output.Separator)
+      .filter(name => !fixedBuckets.contains(name) && name != timeName)
+    var fieldsPk = getFields(tbSchema, false)
     var modifiedSchema = false
 
     if (!fixedBuckets.isEmpty) {
       fixedBuckets.foreach(bucket => {
-        tableName += Output.SEPARATOR + bucket
-        fields = fields ++ Seq(Output.getFieldType(fixedBucketsType, bucket, false))
+        tableName = tableName ++ Array(bucket)
+        fieldsPk = fieldsPk ++ Seq(Output.getFieldType(fixedBucketsType, bucket, false))
         modifiedSchema = true
       })
     }
 
-    if (!timeName.isEmpty) {
-      tableName += Output.SEPARATOR + timeName
-      fields = fields ++ Seq(Output.getFieldType(dateType, timeName, false))
-    }
-
-    if (isAutoCalculateId && !tbSchema.schema.fieldNames.contains(Output.ID)) {
-      tableName += Output.SEPARATOR + Output.ID
-      fields = fields ++ Seq(Output.defaultStringField(Output.ID, false))
+    if (isAutoCalculateId && !tbSchema.schema.fieldNames.contains(Output.Id)) {
+      tableName = Array(Output.Id) ++ tableName
+      fieldsPk = Seq(Output.defaultStringField(Output.Id, false)) ++ fieldsPk
       modifiedSchema = true
     }
 
-    if (modifiedSchema) new TableSchema(tbSchema.outputName, tableName, StructType(fields)) else tbSchema
+    if (!timeName.isEmpty) {
+      tableName = tableName ++ Array(timeName)
+      fieldsPk = fieldsPk ++ Seq(Output.getFieldType(dateType, timeName, false))
+      modifiedSchema = true
+    }
+
+    if (modifiedSchema){
+      fieldsPk = fieldsPk ++ getFields(tbSchema, true)
+      new TableSchema(tbSchema.outputName, tableName.mkString(Output.Separator), StructType(fieldsPk))
+    } else tbSchema
   }
 
+  protected def getFields(tbSchema: TableSchema, nullables: Boolean) : Seq[StructField] =
+    tbSchema.schema.fields.toSeq.filter(field =>
+    !fixedBuckets.contains(field.name) && field.name != timeName && field.nullable == nullables)
+
   protected def genericRowSchema(rdd: RDD[(Option[String], Row)]): (Option[String], RDD[Row]) =
-    (Some(rdd.map(rowType => rowType._1.get.split(Output.SEPARATOR))
-      .reduce((names1, names2) => if (names1.length > names2.length) names1 else names2).mkString(Output.SEPARATOR)),
+    (Some(rdd.map(rowType => rowType._1.get.split(Output.Separator))
+      .reduce((names1, names2) => if (names1.length > names2.length) names1 else names2).mkString(Output.Separator)),
       extractRow(rdd))
 
   protected def extractRow(rdd: RDD[(Option[String], Row)]): RDD[Row] = rdd.map(rowType => rowType._2)
@@ -154,7 +164,7 @@ abstract class Output(keyName: String,
     if (bcSchema.isDefined) {
       bcSchema.get.value.filter(schemaFilter => schemaFilter.outputName == keyName &&
         getFixedBucketsAndTimeBucket.forall(schemaFilter.schema.fieldNames.contains(_) &&
-          schemaFilter.schema.filter(!_.nullable).length > 1))
+          schemaFilter.schema.filter(!_.nullable).length >= 1))
     } else Seq()
 
   protected def checkOperationTypes: Boolean = {
@@ -172,8 +182,11 @@ abstract class Output(keyName: String,
 
 object Output {
 
-  final val SEPARATOR = "_"
-  final val ID = "id"
+  final val Separator = "_"
+  final val Id = "id"
+  final val FixedAggregation = "fixedAggregation"
+  final val FixedAggregationSeparator = ":"
+  final val Multiplexer = "multiplexer"
 
   def getFieldType(dateTimeType: TypeOp, fieldName: String, nullable: Boolean): StructField =
     dateTimeType match {

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/Output.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/Output.scala
@@ -110,6 +110,7 @@ abstract class Output(keyName: String,
       }))
     }
 
+  //TODO refactor for remove var types
   protected def getTableSchemaFixedId(tbSchema: TableSchema): TableSchema = {
     var tableName = tbSchema.tableName.split(Output.Separator)
       .filter(name => !fixedBuckets.contains(name) && name != timeName)


### PR DESCRIPTION
In this PR I must change the SDK, because the order of the fields in the schema and Dataframe is very important. 

If we create a table with primarykey((field1, field2),field3), the order in cassandra and the dataframe is field1, field2, field3, always behind the other fields of the table.

We have a bug in the ouput sdk to find schema in broadcast variable.