### PR TITLE
Typo in configuration of CuratorFactoryHolderIT

### DIFF
--- a/driver/src/test/scala/com/stratio/sparkta/driver/test/factory/CuratorFactoryHolderIT.scala
+++ b/driver/src/test/scala/com/stratio/sparkta/driver/test/factory/CuratorFactoryHolderIT.scala
@@ -102,7 +102,7 @@ object CuratorFactoryHolderIT {
                           "connectionString": "localhost:$TestServerZKPort",
                           "connectionTimeout": 15000,
                           "sessionTimeout": 60000
-                          "retryAttemps": 5
+                          "retryAttempts": 5
                           "retryInterval": 2000
                         }
                       """


### PR DESCRIPTION
Due to a typo in the configuration, CuratoryFactoryHolderIT was failing.