### PR TITLE
Cassandra tables were overriden. Close #233

### DIFF
--- a/plugins/output-cassandra/src/main/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraOutput.scala
+++ b/plugins/output-cassandra/src/main/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraOutput.scala
@@ -121,7 +121,7 @@ class CassandraOutput(keyName: String,
   }
 
   override def upsert(dataFrame: DataFrame, tableName: String): Unit = {
-    dataFrame.save("org.apache.spark.sql.cassandra", Overwrite, Map("c_table" -> tableName, "keyspace" -> keyspace))
+    dataFrame.save("org.apache.spark.sql.cassandra", Append, Map("c_table" -> tableName, "keyspace" -> keyspace))
   }
 }
 


### PR DESCRIPTION
Tables were always updated to values of last dataframe data