### PR TITLE
Parquet output, issue #75

### DIFF
--- a/doc/src/site/sphinx/outputs.rst
+++ b/doc/src/site/sphinx/outputs.rst
@@ -14,6 +14,8 @@ Outputs Configurations
 
 - :ref:`print-label`
 
+- :ref:`parquet-label`
+
 
 .. image:: images/outputs.png
    :height: 400 px
@@ -412,3 +414,26 @@ Print Configuration
 
 The print output uses the generic implementation with DataFrames, this implementation print each dataframe with his
  schema.
+
+.. _parquet-label:
+
+Parquet Configuration
+==========
+
+The parquet output uses generic implementation of DataFrames. This output has the following parameters:
+
+* path:
+   Destination path to store info. Required.
+
+   * Example:
+::
+
+   "path": "file:///path-to-parquet-ds"
+
+* datePattern:
+   You can specify a formatting pattern for dates. This is for split subfolders
+
+   * Example:
+::
+
+  "dateFormat": "yyyy/MM/dd" ==> "/path-to-parquet-ds/agg-name/2011/07/19/..."

--- a/examples/policies/ITwitter-OParquet.json
+++ b/examples/policies/ITwitter-OParquet.json
@@ -1,0 +1,89 @@
+{
+  "name": "policy-Twitter-Parquet",
+  "duration": 10000,
+  "saveRawData": "false",
+  "rawDataParquetPath": "myTestParquetPath",
+  "checkpointDir": "checkpoint",
+  "timeBucket": "minute",
+  "checkpointGranularity": "minute",
+  "checkpointInterval": 30000,
+  "checkpointTimeAvailability": 60000,
+  "inputs": [
+    {
+      "name": "in-twitter",
+      "elementType": "TwitterInput",
+      "configuration": {
+        "consumerKey": "***",
+        "consumerSecret": "***",
+        "accessToken": "***",
+        "accessTokenSecret": "***"
+      }
+    }
+  ],
+  "dimensions": [
+    {
+      "dimensionType": "TwitterStatusBucketer",
+      "name": "status"
+    },
+    {
+      "dimensionType": "PassthroughBucketer",
+      "name": "wordsN"
+    },
+    {
+      "dimensionType": "DateTimeBucketer",
+      "name": "timestamp"
+    }
+  ],
+  "rollups": [
+    {
+      "dimensionAndBucketTypes": [
+        {
+          "dimensionName": "status",
+          "bucketType": "hastags"
+        },
+        {
+          "dimensionName": "status",
+          "bucketType": "retweets"
+        },
+        {
+          "dimensionName": "timestamp",
+          "bucketType": "minute"
+        }
+      ],
+      "operators": ["count-operator","sum-operator","max-operator","min-operator","range-operator","avg-operator",
+        "median-operator",
+        "variance-operator","stddev-operator","fullText-operator","lastValue-operator","firstValue-operator","accumulator-operator"]
+    }
+  ],
+  "outputs": [
+    {
+      "name": "out-parquet",
+      "elementType": "ParquetOutput",
+      "configuration": {
+        "path": "path-to-parquet",
+        "datePattern": "yyyy/MM/dd"
+      }
+    }
+  ],
+  "operators": [
+    {
+      "name": "count-operator",
+      "elementType": "CountOperator",
+      "configuration": {}
+    },
+    {
+      "name": "count-distinct-operator",
+      "elementType": "CountOperator",
+      "configuration": {
+        "distinctFields": "wordsN"
+      }
+    },
+    {
+      "name": "sum-operator",
+      "elementType": "SumOperator",
+      "configuration": {
+        "inputField": "wordsN"
+      }
+    }
+  ]
+}

--- a/plugins/bucketer-dateTime/pom.xml
+++ b/plugins/bucketer-dateTime/pom.xml
@@ -30,8 +30,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
+            <groupId>com.github.nscala-time</groupId>
+            <artifactId>nscala-time_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/plugins/output-parquet/pom.xml
+++ b/plugins/output-parquet/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2015 Stratio (http://stratio.com)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>plugins</artifactId>
+        <groupId>com.stratio.sparkta</groupId>
+        <version>0.5.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>output-parquet</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.nscala-time</groupId>
+            <artifactId>nscala-time_${scala.binary.version}</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/plugins/output-parquet/src/main/scala/com/stratio/sparkta/plugin/output/parquet/ParquetOutput.scala
+++ b/plugins/output-parquet/src/main/scala/com/stratio/sparkta/plugin/output/parquet/ParquetOutput.scala
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparkta.plugin.output.parquet
+
+import java.io.{Serializable => JSerializable}
+import scala.util.Try
+
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.sql._
+import org.apache.spark.{Logging, SparkContext}
+
+import com.stratio.sparkta.sdk.TypeOp._
+import com.stratio.sparkta.sdk.ValidatingPropertyMap._
+import com.stratio.sparkta.sdk.WriteOp.WriteOp
+import com.stratio.sparkta.sdk._
+
+/**
+ * This output save as parquet file the information.
+ * @param keyName
+ * @param properties
+ * @param sparkContext
+ * @param operationTypes
+ * @param bcSchema
+ */
+class ParquetOutput(keyName: String,
+                    properties: Map[String, JSerializable],
+                    @transient sparkContext: SparkContext,
+                    operationTypes: Option[Broadcast[Map[String, (WriteOp, TypeOp)]]],
+                    bcSchema: Option[Broadcast[Seq[TableSchema]]],
+                    timeName: String)
+  extends Output(keyName, properties, sparkContext, operationTypes, bcSchema, timeName: String) with Logging {
+
+  override val supportedWriteOps = Seq(WriteOp.Inc, WriteOp.IncBig, WriteOp.Set, WriteOp.Max, WriteOp.Min,
+    WriteOp.AccAvg, WriteOp.AccMedian, WriteOp.AccVariance, WriteOp.AccStddev, WriteOp.FullText, WriteOp.AccSet)
+
+  override val multiplexer = Try(properties.getString("multiplexer").toBoolean).getOrElse(false)
+
+  override val isAutoCalculateId = Try(properties.getString("isAutoCalculateId").toBoolean).getOrElse(false)
+
+  override def upsert(dataFrame: DataFrame, tableName: String): Unit = {
+    val path = properties.getString("path", None)
+    require(path.isDefined, "Destination path is required. You have to set 'path' on properties")
+    val subPath = DateOperations.subPath(timeName, properties.getString("datePattern", None))
+    dataFrame.save("parquet", SaveMode.Overwrite, Map("spark.sql.parquet.binaryAsString" -> "true",
+      "path" -> s"${path.get}/$tableName$subPath"))
+  }
+}

--- a/plugins/output-parquet/src/test/scala/com/stratio/sparkta/plugin/output/parquet/ParquetOutputSpec.scala
+++ b/plugins/output-parquet/src/test/scala/com/stratio/sparkta/plugin/output/parquet/ParquetOutputSpec.scala
@@ -1,0 +1,114 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparkta.plugin.output.parquet
+
+import scala.reflect.io.File
+
+import com.github.nscala_time.time.Imports._
+import org.apache.log4j.{Level, Logger}
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.SQLContext
+import org.junit.runner.RunWith
+import org.scalatest._
+import org.scalatest.junit.JUnitRunner
+
+import com.stratio.sparkta.sdk.DateOperations
+
+@RunWith(classOf[JUnitRunner])
+class ParquetOutputSpec extends FlatSpec with ShouldMatchers with BeforeAndAfterAll {
+  self: FlatSpec =>
+
+  @transient var sc: SparkContext = _
+
+  override def beforeAll {
+    Logger.getRootLogger.setLevel(Level.ERROR)
+    sc = ParquetOutputSpec.getNewLocalSparkContext(1, "test")
+  }
+
+  override def afterAll {
+    sc.stop()
+    System.clearProperty("spark.driver.port")
+  }
+
+  trait CommonValues {
+
+    val sqlContext = new SQLContext(sc)
+
+    import sqlContext.implicits._
+
+    val data = sc.parallelize(Seq(Person("Kevin", 18), Person("Kira", 21), Person("Ariadne", 26))).toDF
+    val tmpPath: String = File.makeTemp().name
+  }
+
+  trait WithEventData extends CommonValues {
+
+    val properties = Map("path" -> tmpPath)
+    val output = new ParquetOutput("parquet-test", properties, sc, None, None, "minute")
+  }
+
+  trait WithWrongOutput extends CommonValues {
+
+    val output = new ParquetOutput("parquet-test", Map(), sc, None, None, "")
+  }
+
+  trait WithDatePattern extends CommonValues {
+
+    val datePattern = "yyyy/MM/dd"
+    val properties = Map("path" -> tmpPath, "datePattern" -> datePattern)
+    val granularity = "minute"
+    val output = new ParquetOutput("parquet-test", properties, sc, None, None, granularity)
+    val dt = DateTime.now
+    val expectedPath = "/" + DateTimeFormat.forPattern(datePattern).print(dt) + "/" + dt.withMillisOfSecond(0)
+      .withSecondOfMinute(0).getMillis
+  }
+
+  trait WithoutGranularity extends CommonValues {
+
+    val datePattern = "yyyy/MM/dd"
+    val properties = Map("path" -> tmpPath, "datePattern" -> datePattern)
+    val output = new ParquetOutput("parquet-test", properties, sc, None, None, "")
+    val expectedPath = "/0"
+  }
+
+  "ParquetOutputSpec" should "save a dataframe" in new WithEventData {
+    output.upsert(data, "person")
+    val read = sqlContext.parquetFile(tmpPath).toDF
+    read.count should be(3)
+    read should be eq (data)
+    File(tmpPath).deleteRecursively
+  }
+
+  it should "throw an exception when path is not present" in new WithWrongOutput {
+    an[Exception] should be thrownBy output.upsert(data, "person")
+  }
+
+  it should "format path with pattern" in new WithDatePattern {
+    DateOperations.subPath(granularity, Some(datePattern)) should be(expectedPath)
+  }
+
+  it should "format path ignoring pattern" in new WithoutGranularity {
+    DateOperations.subPath("", Some(datePattern)) should be(expectedPath)
+  }
+}
+
+object ParquetOutputSpec {
+
+  def getNewLocalSparkContext(numExecutors: Int = 1, title: String): SparkContext =
+    new SparkContext(s"local[$numExecutors]", title)
+}
+
+case class Person(name: String, age: Int) extends Serializable

--- a/plugins/parser-datetime/pom.xml
+++ b/plugins/parser-datetime/pom.xml
@@ -30,8 +30,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
+            <groupId>com.github.nscala-time</groupId>
+            <artifactId>nscala-time_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -37,6 +37,7 @@
         <module>output-cassandra</module>
         <module>output-redis</module>
         <module>output-print</module>
+        <module>output-parquet</module>
         <module>operator-count</module>
         <module>operator-sum</module>
         <module>operator-max</module>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <scala.version>2.10.4</scala.version>
         <spark.version>1.3.0</spark.version>
         <slf4j.version>1.7.7</slf4j.version>
-        <joda.time.version>2.5</joda.time.version>
+        <nscala.time.version>2.0.0</nscala.time.version>
         <scalatest.version>2.2.2</scalatest.version>
         <mockito.version>1.10.5</mockito.version>
     </properties>
@@ -166,9 +166,9 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>${joda.time.version}</version>
+                <groupId>com.github.nscala-time</groupId>
+                <artifactId>nscala-time_${scala.binary.version}</artifactId>
+                <version>${nscala.time.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.scala-lang</groupId>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -42,8 +42,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
+            <groupId>com.github.nscala-time</groupId>
+            <artifactId>nscala-time_${scala.binary.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>com.datastax.spark</groupId>

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/DateOperations.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/DateOperations.scala
@@ -18,13 +18,15 @@ package com.stratio.sparkta.sdk
 
 import java.sql.Timestamp
 
-import org.joda.time.DateTime
+import com.github.nscala_time.time.Imports._
 
 object DateOperations {
 
+  final val Slash: String = "/"
+
   def getTimeFromGranularity(timeBucket: Option[String], granularity: Option[String]): Long =
     (timeBucket, granularity) match {
-      case (Some(time), Some(granularity)) => dateFromGranularity(DateTime.now(), granularity)
+      case (Some(time), Some(granularity)) => dateFromGranularity(DateTime.now, granularity)
       case _ => 0L
     }
 
@@ -48,4 +50,10 @@ object DateOperations {
   }
 
   def millisToTimeStamp(date: Long): Timestamp = new Timestamp(date)
+
+  def subPath(granularity: String, datePattern: Option[String]): String = {
+    val suffix = dateFromGranularity(DateTime.now, granularity)
+    if (!datePattern.isDefined || suffix.equals(0L)) Slash + suffix
+    else Slash + DateTimeFormat.forPattern(datePattern.get).print(new DateTime(suffix)) + Slash + suffix
+  }
 }

--- a/sdk/src/test/scala/com/stratio/sparkta/sdk/DateOperationsSpec.scala
+++ b/sdk/src/test/scala/com/stratio/sparkta/sdk/DateOperationsSpec.scala
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparkta.sdk
+
+import com.github.nscala_time.time.Imports._
+import org.junit.runner.RunWith
+import org.scalatest._
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class DateOperationsSpec extends FlatSpec with ShouldMatchers {
+
+  trait CommonValues {
+
+    val granularity = "day"
+    val datePattern = "yyyy/MM/dd"
+    val expectedPath = "/" + DateTimeFormat.forPattern(datePattern) +
+      DateOperations.dateFromGranularity(DateTime.now, granularity)
+    val dt = DateTime.now
+    val minuteDT = dt.withMillisOfSecond(0).withSecondOfMinute(0)
+    val hourDT = minuteDT.withMinuteOfHour(0)
+    val dayDT = hourDT.withHourOfDay(0)
+    val monthDT = dayDT.withDayOfMonth(1)
+    val yearDT = monthDT.withMonthOfYear(1)
+    val wrongDT = 0L
+  }
+
+  trait FailValues {
+
+    val emptyGranularity = ""
+    val badGranularity = "minutely"
+    val granularity = "minute"
+    val datePattern = Some("yyyy/MM/dd")
+    val emptyPattern = None
+    val expectedPath = "/0"
+    val dt = DateTime.now
+    val expectedGranularityPath = "/" + dt.withMillisOfSecond(0).withSecondOfMinute(0).getMillis
+    val expectedGranularityWithPattern = "/" + DateTimeFormat.forPattern(datePattern.get).print(dt) + "/" +
+      dt.withMillisOfSecond(0).withSecondOfMinute(0).getMillis
+  }
+
+  "DateOperationsSpec" should "return timestamp with correct parameters" in new CommonValues {
+    DateOperations.getTimeFromGranularity(Some(""), Some("minute")) should be(minuteDT.getMillis)
+    DateOperations.getTimeFromGranularity(Some(""), Some("hour")) should be(hourDT.getMillis)
+    DateOperations.getTimeFromGranularity(Some(""), Some("day")) should be(dayDT.getMillis)
+    DateOperations.getTimeFromGranularity(Some(""), Some("month")) should be(monthDT.getMillis)
+    DateOperations.getTimeFromGranularity(Some(""), Some("year")) should be(yearDT.getMillis)
+    DateOperations.getTimeFromGranularity(Some("asdasd"), Some("year")) should be(yearDT.getMillis)
+    DateOperations.getTimeFromGranularity(Some(""), Some("bad")) should be(wrongDT)
+  }
+
+  it should "return parsed timestamp with granularity" in new CommonValues {
+    DateOperations.dateFromGranularity(dt, "minute") should be(minuteDT.getMillis)
+    DateOperations.dateFromGranularity(dt, "hour") should be(hourDT.getMillis)
+    DateOperations.dateFromGranularity(dt, "day") should be(dayDT.getMillis)
+    DateOperations.dateFromGranularity(dt, "month") should be(monthDT.getMillis)
+    DateOperations.dateFromGranularity(dt, "year") should be(yearDT.getMillis)
+    DateOperations.dateFromGranularity(dt, "bad") should be(wrongDT)
+  }
+
+  it should "format path ignoring pattern" in new FailValues {
+    DateOperations.subPath(badGranularity, datePattern) should be(expectedPath)
+    DateOperations.subPath(badGranularity, datePattern) should be(expectedPath)
+    DateOperations.subPath(badGranularity, emptyPattern) should be(expectedPath)
+    DateOperations.subPath(granularity, emptyPattern) should be(expectedGranularityPath)
+    DateOperations.subPath(granularity, datePattern) should be(expectedGranularityWithPattern)
+  }
+}


### PR DESCRIPTION
#### Description
Output for parquet files. It closes issue #75. We need an extra parameter ```path``` and optional one ```datePattern``` if you want path formatting. I changed joda-time by NScala-time (Scala wrapper). Also I changed a tailrec function to improve readability. Added methods to DateOperations to calculate paths with patterns and granularity.

#### Reviewer
@arinconstrio 

#### Test
Added 7 test. All passed

#### Scalastyle
All test passed.