### PR TITLE
Feature/splitter parser

### DIFF
--- a/plugins/input-twitter/src/main/scala/com/stratio/sparkta/plugin/input/twitter/TwitterInput.scala
+++ b/plugins/input-twitter/src/main/scala/com/stratio/sparkta/plugin/input/twitter/TwitterInput.scala
@@ -58,6 +58,7 @@ class TwitterInput(properties: Map[String, JSerializable]) extends Input(propert
       "retweets" -> data.getRetweetCount,
       "userLocation" -> data.getUser.getLocation.toLowerCase,
       "timestamp" ->  data.getCreatedAt,
+      "text"-> data.getText,
       "geolocation" -> (data.getGeoLocation match {
         case null => None
         case _ => Some((data.getGeoLocation.getLatitude + "__" + data.getGeoLocation.getLongitude))

--- a/plugins/parser-split/pom.xml
+++ b/plugins/parser-split/pom.xml
@@ -1,0 +1,26 @@
+<!--
+    Copyright (C) 2014 Stratio (http://stratio.com)
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+            http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>plugins</artifactId>
+        <groupId>com.stratio.sparkta</groupId>
+        <version>0.5.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>parser-split</artifactId>
+
+
+</project>

--- a/plugins/parser-split/src/main/scala/com/stratio/sparkta/plugin/parser/split/SplitParser.scala
+++ b/plugins/parser-split/src/main/scala/com/stratio/sparkta/plugin/parser/split/SplitParser.scala
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.sparkta.plugin.parser.split
+
+import com.stratio.sparkta.sdk.{Event, Parser}
+import com.stratio.sparkta.sdk.ValidatingPropertyMap._
+
+import scala.util.{Failure, Success, Try}
+
+/**
+ * @author arincon
+ */
+class SplitParser(properties: Map[String, Serializable]) extends Parser(properties) {
+  val txtField = properties.getString(SplitParser.TextField)
+  val splitter = properties.getString(SplitParser.Splitter)
+  val resultField = properties.getString(SplitParser.ResultField)
+
+  override def parse(data: Event): Event = {
+    val txtValue = data.keyMap.getOrElse(txtField, None)
+   val myTry= Try {
+      Map(resultField -> txtValue.toString.split(splitter).toList)
+    }
+   val result= myTry match {
+      case Success(x) => new Event(data.keyMap ++ x.asInstanceOf[Map[String, Serializable]])
+      case Failure(_) => data
+    }
+    result
+  }
+}
+
+object SplitParser {
+
+  final val TextField = "textField"
+  final val Splitter = "splitter"
+  final val ResultField = "resultField"
+}

--- a/plugins/parser-split/src/main/scala/com/stratio/sparkta/plugin/parser/split/SplitParser.scala
+++ b/plugins/parser-split/src/main/scala/com/stratio/sparkta/plugin/parser/split/SplitParser.scala
@@ -15,8 +15,8 @@
  */
 package com.stratio.sparkta.plugin.parser.split
 
-import com.stratio.sparkta.sdk.{Event, Parser}
 import com.stratio.sparkta.sdk.ValidatingPropertyMap._
+import com.stratio.sparkta.sdk.{Event, Parser}
 
 import scala.util.{Failure, Success, Try}
 
@@ -30,10 +30,10 @@ class SplitParser(properties: Map[String, Serializable]) extends Parser(properti
 
   override def parse(data: Event): Event = {
     val txtValue = data.keyMap.getOrElse(txtField, None)
-   val myTry= Try {
+    val splitted = Try {
       Map(resultField -> txtValue.toString.split(splitter).toList)
     }
-   val result= myTry match {
+    val result = splitted match {
       case Success(x) => new Event(data.keyMap ++ x.asInstanceOf[Map[String, Serializable]])
       case Failure(_) => data
     }

--- a/plugins/parser-split/src/test/scala/com/stratio/sparkta/plugin/parser/split/SplitParserSpec.scala
+++ b/plugins/parser-split/src/test/scala/com/stratio/sparkta/plugin/parser/split/SplitParserSpec.scala
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.sparkta.plugin.parser.split
+
+import com.stratio.sparkta.sdk.Event
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{Matchers, WordSpec}
+
+/**
+ * Created by arincon on 3/06/15.
+ */
+@RunWith(classOf[JUnitRunner])
+class SplitParserSpec extends WordSpec with Matchers {
+
+
+  val inputEvent: Event = new Event(Map("text" -> "hola mundo hola mundito"))
+
+  "The SplitParser" should {
+    "add a tuple with a list" in {
+      val properties: Map[String, Serializable] = Map("textField" -> "text", "splitter" -> " ", "resultField" -> "parsedText").asInstanceOf[Map[String, Serializable]]
+      val parser = new SplitParser(properties)
+      val resultEvent = parser.parse(inputEvent)
+      resultEvent.keyMap.get("parsedText") should be(Some(List("hola", "mundo", "hola", "mundito")))
+    }
+  }
+
+}

--- a/plugins/parser-split/src/test/scala/com/stratio/sparkta/plugin/parser/split/SplitParserSpec.scala
+++ b/plugins/parser-split/src/test/scala/com/stratio/sparkta/plugin/parser/split/SplitParserSpec.scala
@@ -20,9 +20,7 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{Matchers, WordSpec}
 
-/**
- * Created by arincon on 3/06/15.
- */
+
 @RunWith(classOf[JUnitRunner])
 class SplitParserSpec extends WordSpec with Matchers {
 

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -61,6 +61,7 @@
         <module>input-rabbitMQ</module>
         <module>parser-detector</module>
         <module>parser-type</module>
+        <module>parser-split</module>
     </modules>
 
     <dependencies>


### PR DESCRIPTION
#### Description

Split parser is the first step to achieve the word count example

This is a conf example


  "parsers": [
    {
      "name": "split-parser",
      "elementType": "SplitParser",
      "configuration": {
        "textField": "text",
        "splitter": " ",
        "resultField": "splitted"
      }
    }
  ]

#### Reviewer

@anistal  

#### Test

1 added. All passed

#### Scalastyle

All test passed.