### PR TITLE
New trait for type conversions and operators with supervised types

### DIFF
--- a/aggregator/src/main/scala/com/stratio/sparkta/aggregator/DataCube.scala
+++ b/aggregator/src/main/scala/com/stratio/sparkta/aggregator/DataCube.scala
@@ -75,7 +75,7 @@ case class DataCube(dimensions: Seq[Dimension],
       case Some(bucket) => {
         val dimensionsDates =
           dimensionValues.filter(dimensionValue => dimensionValue.dimensionBucket.bucketType.id == bucket)
-        if (dimensionsDates.isEmpty) getDate else dimensionsDates.head.value.asInstanceOf[Long]
+        if (dimensionsDates.isEmpty) getDate else DateOperations.getMillisFromSerializable(dimensionsDates.head.value)
       }
       case None => getDate
     }

--- a/examples/policies/ITwitter-OPrint.json
+++ b/examples/policies/ITwitter-OPrint.json
@@ -119,14 +119,16 @@
       "name": "max-operator",
       "elementType": "MaxOperator",
       "configuration": {
-        "inputField": "wordsN"
+        "inputField": "wordsN",
+        "typeOp": "string"
       }
     },
     {
       "name": "min-operator",
       "elementType": "MinOperator",
       "configuration": {
-        "inputField": "wordsN"
+        "inputField": "wordsN",
+        "typeOp": "string"
       }
     },
     {

--- a/plugins/dimension-dateTime/src/main/scala/com/stratio/sparkta/plugin/dimension/datetime/DateTimeDimension.scala
+++ b/plugins/dimension-dateTime/src/main/scala/com/stratio/sparkta/plugin/dimension/datetime/DateTimeDimension.scala
@@ -33,7 +33,7 @@ case class DateTimeDimension(props: Map[String, JSerializable]) extends Bucketer
 
   override val defaultTypeOperation = TypeOp.Timestamp
 
-  override val operationProps : Map[String, JSerializable] = props
+  override val operationProps: Map[String, JSerializable] = props
 
   override val properties: Map[String, JSerializable] = props ++ {
     if (!props.contains(GranularityPropertyName)) Map(GranularityPropertyName -> DefaultGranularity) else Map()
@@ -76,11 +76,12 @@ object DateTimeDimension {
   final val timestamp = Bucketer.getTimestamp(Some(TypeOp.Timestamp), TypeOp.Timestamp)
 
   def bucket(value: Date, bucketType: BucketType, properties: Map[String, JSerializable]): JSerializable = {
-    DateOperations.dateFromGranularity(new DateTime(value), bucketType match {
-      case t if t == timestamp => if (properties.contains(GranularityPropertyName))
-        properties.get(GranularityPropertyName).get.toString
-      else DefaultGranularity
-      case _ => bucketType.id
-    }).asInstanceOf[JSerializable]
+    TypeOp.transformValueByTypeOp(bucketType.typeOp,
+      DateOperations.dateFromGranularity(new DateTime(value), bucketType match {
+        case t if t == timestamp => if (properties.contains(GranularityPropertyName))
+          properties.get(GranularityPropertyName).get.toString
+        else DefaultGranularity
+        case _ => bucketType.id
+      })).asInstanceOf[JSerializable]
   }
 }

--- a/plugins/dimension-dateTime/src/main/scala/com/stratio/sparkta/plugin/dimension/datetime/DateTimeDimension.scala
+++ b/plugins/dimension-dateTime/src/main/scala/com/stratio/sparkta/plugin/dimension/datetime/DateTimeDimension.scala
@@ -33,6 +33,8 @@ case class DateTimeDimension(props: Map[String, JSerializable]) extends Bucketer
 
   override val defaultTypeOperation = TypeOp.Timestamp
 
+  override val operationProps : Map[String, JSerializable] = props
+
   override val properties: Map[String, JSerializable] = props ++ {
     if (!props.contains(GranularityPropertyName)) Map(GranularityPropertyName -> DefaultGranularity) else Map()
   }

--- a/plugins/dimension-geoHash/src/main/scala/com/stratio/sparkta/plugin/dimension/geohash/GeoHashDimension.scala
+++ b/plugins/dimension-geoHash/src/main/scala/com/stratio/sparkta/plugin/dimension/geohash/GeoHashDimension.scala
@@ -119,7 +119,7 @@ object GeoHashDimension {
 
   //scalastyle:off
   def bucket(lat: Double, long: Double, bucketType: BucketType): JSerializable = {
-    bucketType match {
+    TypeOp.transformValueByTypeOp(bucketType.typeOp, bucketType match {
       case p if p.id == Precision1Name => decodeHash(GeoHash.encodeHash(lat, long, 1))
       case p if p.id == Precision2Name => decodeHash(GeoHash.encodeHash(lat, long, 2))
       case p if p.id == Precision3Name => decodeHash(GeoHash.encodeHash(lat, long, 3))
@@ -132,7 +132,7 @@ object GeoHashDimension {
       case p if p.id == Precision10Name => decodeHash(GeoHash.encodeHash(lat, long, 10))
       case p if p.id == Precision11Name => decodeHash(GeoHash.encodeHash(lat, long, 11))
       case p if p.id == Precision12Name => decodeHash(GeoHash.encodeHash(lat, long, 12))
-    }
+    })
   }
 
   //scalastyle:on

--- a/plugins/dimension-geoHash/src/main/scala/com/stratio/sparkta/plugin/dimension/geohash/GeoHashDimension.scala
+++ b/plugins/dimension-geoHash/src/main/scala/com/stratio/sparkta/plugin/dimension/geohash/GeoHashDimension.scala
@@ -22,7 +22,7 @@ import akka.event.slf4j.SLF4JLogging
 import com.github.davidmoten.geo.{GeoHash, LatLong}
 
 import com.stratio.sparkta.plugin.dimension.geohash.GeoHashDimension._
-import com.stratio.sparkta.sdk.{BucketType, Bucketer, TypeOp}
+import com.stratio.sparkta.sdk._
 
 /**
  *
@@ -43,13 +43,15 @@ import com.stratio.sparkta.sdk.{BucketType, Bucketer, TypeOp}
  * 12 - 3.7cm x 1.9cm
  *
  */
-case class GeoHashDimension(props: Map[String, JSerializable]) extends Bucketer with SLF4JLogging {
+case class GeoHashDimension(props: Map[String, JSerializable]) extends Bucketer with JSerializable with SLF4JLogging {
 
   def this() {
     this(Map())
   }
 
   override val properties: Map[String, JSerializable] = props
+
+  override val operationProps : Map[String, JSerializable] = props
 
   override val defaultTypeOperation = TypeOp.ArrayDouble
 

--- a/plugins/dimension-hierarchy/src/main/scala/com/stratio/sparkta/plugin/dimension/hierarchy/HierarchyDimension.scala
+++ b/plugins/dimension-hierarchy/src/main/scala/com/stratio/sparkta/plugin/dimension/hierarchy/HierarchyDimension.scala
@@ -24,13 +24,15 @@ import com.stratio.sparkta.plugin.dimension.hierarchy.HierarchyDimension._
 import com.stratio.sparkta.sdk.ValidatingPropertyMap._
 import com.stratio.sparkta.sdk._
 
-case class HierarchyDimension(props: Map[String, JSerializable]) extends Bucketer with SLF4JLogging {
+case class HierarchyDimension(props: Map[String, JSerializable]) extends Bucketer with JSerializable with SLF4JLogging {
 
   def this() {
     this(Map())
   }
 
   override val defaultTypeOperation = TypeOp.String
+
+  override val operationProps : Map[String, JSerializable] = props
 
   override val properties: Map[String, JSerializable] = props ++ {
     if (!props.contains(SplitterPropertyName)) Map(SplitterPropertyName -> DefaultSplitter) else Map()

--- a/plugins/dimension-hierarchy/src/main/scala/com/stratio/sparkta/plugin/dimension/hierarchy/HierarchyDimension.scala
+++ b/plugins/dimension-hierarchy/src/main/scala/com/stratio/sparkta/plugin/dimension/hierarchy/HierarchyDimension.scala
@@ -30,7 +30,7 @@ case class HierarchyDimension(props: Map[String, JSerializable]) extends Buckete
     this(Map())
   }
 
-  override val defaultTypeOperation = TypeOp.String
+  override val defaultTypeOperation = TypeOp.ArrayString
 
   override val operationProps : Map[String, JSerializable] = props
 
@@ -59,7 +59,8 @@ case class HierarchyDimension(props: Map[String, JSerializable]) extends Buckete
 
   override def bucket(value: JSerializable): Map[BucketType, JSerializable] =
     bucketTypes.map(bucketType =>
-      (bucketType._2, bucket(value.asInstanceOf[String], bucketType._2).asInstanceOf[JSerializable]))
+      (bucketType._2, TypeOp.transformValueByTypeOp(bucketType._2.typeOp,
+        bucket(value.asInstanceOf[String], bucketType._2).asInstanceOf[JSerializable])))
 
   def bucket(value: String, bucketType: BucketType): Seq[JSerializable] = {
     bucketType match {

--- a/plugins/dimension-passthrough/src/main/scala/com/stratio/sparkta/plugin/dimension/passthrough/PassthroughDimension.scala
+++ b/plugins/dimension-passthrough/src/main/scala/com/stratio/sparkta/plugin/dimension/passthrough/PassthroughDimension.scala
@@ -22,11 +22,14 @@ import akka.event.slf4j.SLF4JLogging
 
 import com.stratio.sparkta.sdk._
 
-case class PassthroughDimension(props: Map[String, JSerializable]) extends Bucketer with SLF4JLogging {
+case class PassthroughDimension(props: Map[String, JSerializable]) extends Bucketer
+with JSerializable with SLF4JLogging {
 
   def this() {
     this(Map())
   }
+
+  override val operationProps : Map[String, JSerializable] = props
 
   override val properties: Map[String, JSerializable] = props
 

--- a/plugins/dimension-passthrough/src/main/scala/com/stratio/sparkta/plugin/dimension/passthrough/PassthroughDimension.scala
+++ b/plugins/dimension-passthrough/src/main/scala/com/stratio/sparkta/plugin/dimension/passthrough/PassthroughDimension.scala
@@ -36,7 +36,8 @@ with JSerializable with SLF4JLogging {
   override val defaultTypeOperation = TypeOp.String
 
   override def bucket(value: JSerializable): Map[BucketType, JSerializable] = {
-    Map(Bucketer.getIdentity(getTypeOperation, defaultTypeOperation) -> value)
+    val bucketType = Bucketer.getIdentity(getTypeOperation, defaultTypeOperation)
+    Map(bucketType -> TypeOp.transformValueByTypeOp(bucketType.typeOp, value))
   }
 
   override lazy val bucketTypes: Map[String, BucketType] =

--- a/plugins/dimension-tag/src/main/scala/com/stratio/sparkta/plugin/dimension/tag/TagDimension.scala
+++ b/plugins/dimension-tag/src/main/scala/com/stratio/sparkta/plugin/dimension/tag/TagDimension.scala
@@ -21,15 +21,17 @@ import java.io.{Serializable => JSerializable}
 import akka.event.slf4j.SLF4JLogging
 
 import com.stratio.sparkta.plugin.dimension.tag.TagDimension._
-import com.stratio.sparkta.sdk.{BucketType, Bucketer, TypeOp}
+import com.stratio.sparkta.sdk._
 
-case class TagDimension(props: Map[String, JSerializable]) extends Bucketer with SLF4JLogging {
+case class TagDimension(props: Map[String, JSerializable]) extends Bucketer with JSerializable with SLF4JLogging {
 
   def this() {
     this(Map())
   }
 
   override val defaultTypeOperation = TypeOp.String
+
+  override val operationProps : Map[String, JSerializable] = props
 
   override val properties: Map[String, JSerializable] = props
 

--- a/plugins/dimension-tag/src/main/scala/com/stratio/sparkta/plugin/dimension/tag/TagDimension.scala
+++ b/plugins/dimension-tag/src/main/scala/com/stratio/sparkta/plugin/dimension/tag/TagDimension.scala
@@ -29,7 +29,7 @@ case class TagDimension(props: Map[String, JSerializable]) extends Bucketer with
     this(Map())
   }
 
-  override val defaultTypeOperation = TypeOp.String
+  override val defaultTypeOperation = TypeOp.ArrayString
 
   override val operationProps : Map[String, JSerializable] = props
 
@@ -51,9 +51,9 @@ object TagDimension {
   final val AllTagsName = "allTags"
 
   def bucket(value: Iterable[JSerializable], bucketType: BucketType): JSerializable =
-    bucketType.id match {
+    TypeOp.transformValueByTypeOp(bucketType.typeOp, bucketType.id match {
       case name if name == FirstTagName => value.head
       case name if name == LastTagName => value.last
       case name if name == AllTagsName => value.toSeq.asInstanceOf[JSerializable]
-    }
+    })
 }

--- a/plugins/dimension-twitter-status/src/main/scala/com/stratio/sparkta/plugin/dimension/twitter/status/TwitterStatusDimension.scala
+++ b/plugins/dimension-twitter-status/src/main/scala/com/stratio/sparkta/plugin/dimension/twitter/status/TwitterStatusDimension.scala
@@ -55,7 +55,8 @@ with JSerializable with SLF4JLogging {
 
   override def bucket(value: JSerializable): Map[BucketType, JSerializable] = {
     bucketTypes.map(bucketType =>
-      bucketType._2 -> TwitterStatusDimension.bucket(value.asInstanceOf[Status], bucketType._2))
+      bucketType._2 -> TypeOp.transformValueByTypeOp(bucketType._2.typeOp,
+        TwitterStatusDimension.bucket(value.asInstanceOf[Status], bucketType._2)))
   }
 }
 

--- a/plugins/dimension-twitter-status/src/main/scala/com/stratio/sparkta/plugin/dimension/twitter/status/TwitterStatusDimension.scala
+++ b/plugins/dimension-twitter-status/src/main/scala/com/stratio/sparkta/plugin/dimension/twitter/status/TwitterStatusDimension.scala
@@ -18,18 +18,22 @@ package com.stratio.sparkta.plugin.dimension.twitter.status
 
 import java.io.{Serializable => JSerializable}
 
+import akka.event.slf4j.SLF4JLogging
 import twitter4j.Status
 
 import com.stratio.sparkta.plugin.dimension.twitter.status.TwitterStatusDimension._
 import com.stratio.sparkta.sdk._
 
-case class TwitterStatusDimension(props: Map[String, JSerializable]) extends Bucketer {
+case class TwitterStatusDimension(props: Map[String, JSerializable]) extends Bucketer
+with JSerializable with SLF4JLogging {
 
   def this() {
     this(Map())
   }
 
   override val defaultTypeOperation = TypeOp.String
+
+  override val operationProps : Map[String, JSerializable] = props
 
   override val properties: Map[String, JSerializable] = props
 

--- a/plugins/operator-accumulator/src/main/scala/com/stratio/sparkta/plugin/operator/accumulator/AccumulatorOperator.scala
+++ b/plugins/operator-accumulator/src/main/scala/com/stratio/sparkta/plugin/operator/accumulator/AccumulatorOperator.scala
@@ -19,12 +19,14 @@ package com.stratio.sparkta.plugin.operator.accumulator
 import java.io.{Serializable => JSerializable}
 import scala.util.Try
 
+import com.stratio.sparkta.sdk.TypeOp
+import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk.ValidatingPropertyMap._
 import com.stratio.sparkta.sdk._
 
 class AccumulatorOperator(properties: Map[String, JSerializable]) extends Operator(properties) {
 
-  override val typeOp = Some(TypeOp.ArrayString)
+  override val defaultTypeOperation = TypeOp.ArrayString
 
   private val inputField = if(properties.contains("inputField")) Some(properties.getString("inputField")) else None
 
@@ -40,7 +42,7 @@ class AccumulatorOperator(properties: Map[String, JSerializable]) extends Operat
   }
 
   override def processReduce(values : Iterable[Option[Any]]): Option[Any] = {
-    Try(Some(values.map(_.get.toString))).getOrElse(AccumulatorOperator.SOME_EMPTY)
+    Try(Some(transformValueByTypeOp(returnType, values.map(_.get.toString)))).getOrElse(AccumulatorOperator.SOME_EMPTY)
   }
 }
 

--- a/plugins/operator-accumulator/src/test/scala/com/stratio/sparkta/plugin/operator/accumulator/AccumulatorOperatorTestSpec.scala
+++ b/plugins/operator-accumulator/src/test/scala/com/stratio/sparkta/plugin/operator/accumulator/AccumulatorOperatorTestSpec.scala
@@ -45,6 +45,9 @@ class AccumulatorOperatorTestSpec extends WordSpec with Matchers {
 
       val inputFields3 = new AccumulatorOperator(Map())
       inputFields3.processReduce(Seq(Some("a"), Some("b"))) should be(Some(Seq("a", "b")))
+
+      val inputFields4 = new AccumulatorOperator(Map("typeOp" -> "string"))
+      inputFields4.processReduce(Seq(Some(1), Some(1))) should be(Some("1_1"))
     }
   }
 }

--- a/plugins/operator-avg/src/main/scala/com/stratio/sparkta/plugin/operator/avg/AvgOperator.scala
+++ b/plugins/operator-avg/src/main/scala/com/stratio/sparkta/plugin/operator/avg/AvgOperator.scala
@@ -19,12 +19,13 @@ package com.stratio.sparkta.plugin.operator.avg
 import java.io.{Serializable => JSerializable}
 import scala.util.Try
 
+import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk.{TypeOp, WriteOp, Operator}
 import com.stratio.sparkta.sdk.ValidatingPropertyMap._
 
 class AvgOperator(properties: Map[String, JSerializable]) extends Operator(properties) {
 
-  override val typeOp = Some(TypeOp.Double)
+  override val defaultTypeOperation = TypeOp.Double
 
   private val inputField = if(properties.contains("inputField")) Some(properties.getString("inputField")) else None
 
@@ -43,7 +44,8 @@ class AvgOperator(properties: Map[String, JSerializable]) extends Operator(prope
   override def processReduce(values: Iterable[Option[Any]]): Option[Double] = {
     val valuesFiltered = values.flatten
     valuesFiltered.size match {
-      case (nz) if (nz != 0) => Some(valuesFiltered.map(_.asInstanceOf[Number].doubleValue()).sum / valuesFiltered.size)
+      case (nz) if (nz != 0) => Some(transformValueByTypeOp(returnType,
+          valuesFiltered.map(_.asInstanceOf[Number].doubleValue()).sum / valuesFiltered.size))
       case _ => AvgOperator.SOME_ZERO
     }
   }

--- a/plugins/operator-avg/src/test/scala/com/stratio/sparkta/plugin/operator/avg/AvgOperatorSpec.scala
+++ b/plugins/operator-avg/src/test/scala/com/stratio/sparkta/plugin/operator/avg/AvgOperatorSpec.scala
@@ -61,6 +61,9 @@ class AvgOperatorSpec extends WordSpec with Matchers {
       val inputFields4 = new AvgOperator(Map())
       inputFields4.processReduce(Seq(None)) should be(Some(0d))
 
+      val inputFields5 = new AvgOperator(Map("typeOp" -> "string"))
+      inputFields5.processReduce(Seq(Some(1), Some(1))) should be(Some("1.0"))
+
     }
   }
 }

--- a/plugins/operator-count/src/main/scala/com/stratio/sparkta/plugin/operator/count/CountOperator.scala
+++ b/plugins/operator-count/src/main/scala/com/stratio/sparkta/plugin/operator/count/CountOperator.scala
@@ -19,6 +19,8 @@ package com.stratio.sparkta.plugin.operator.count
 import java.io.{Serializable => JSerializable}
 import scala.util.Try
 
+import com.stratio.sparkta.sdk.TypeOp
+import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk.ValidatingPropertyMap._
 import com.stratio.sparkta.sdk._
 
@@ -29,7 +31,7 @@ class CountOperator(properties: Map[String, JSerializable]) extends Operator(pro
     if (fields.isEmpty) None else Some(fields)
   } else None
 
-  override val typeOp = Some(TypeOp.Long)
+  override val defaultTypeOperation = TypeOp.Long
 
   override val key: String = "count" + {
     if (distinctFields.isDefined) "_distinct" else ""
@@ -50,7 +52,7 @@ class CountOperator(properties: Map[String, JSerializable]) extends Operator(pro
         case None => values.map(_.get.asInstanceOf[Number].longValue())
         case Some(fields) => values.toList.distinct.map(value => CountOperator.SomeOne.get)
       }
-      Some(longList.reduce(_ + _))
+      Some(transformValueByTypeOp(returnType, longList.reduce(_ + _)))
     }.getOrElse(CountOperator.SomeZero)
   }
 }

--- a/plugins/operator-count/src/test/scala/com.stratio.sparkta.plugin.operator.count/CountOperatorSpec.scala
+++ b/plugins/operator-count/src/test/scala/com.stratio.sparkta.plugin.operator.count/CountOperatorSpec.scala
@@ -57,6 +57,9 @@ class CountOperatorSpec extends WordSpec with Matchers {
       val inputFields3 = new CountOperator(Map("distinctFields" -> s"field1${CountOperator.Separator}field2"))
       inputFields3.processReduce(Seq(Some(s"field1${CountOperator.Separator}field2" -> 1),
         Some(s"field1${CountOperator.Separator}field2" -> 1))) should be(Some(1L))
+
+      val inputFields5 = new CountOperator(Map("typeOp" -> "string"))
+      inputFields5.processReduce(Seq(Some(1), Some(1))) should be(Some("2"))
     }
   }
 }

--- a/plugins/operator-firstValue/src/main/scala/com/stratio/sparkta/plugin/operator/firstValue/FirstValueOperator.scala
+++ b/plugins/operator-firstValue/src/main/scala/com/stratio/sparkta/plugin/operator/firstValue/FirstValueOperator.scala
@@ -19,12 +19,14 @@ package com.stratio.sparkta.plugin.operator.firstValue
 import java.io.{Serializable => JSerializable}
 import scala.util.Try
 
+import com.stratio.sparkta.sdk.TypeOp
+import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk.ValidatingPropertyMap._
 import com.stratio.sparkta.sdk._
 
 class FirstValueOperator(properties: Map[String, JSerializable]) extends Operator(properties) {
 
-  override val typeOp = Some(TypeOp.String)
+  override val defaultTypeOperation = TypeOp.String
 
   private val inputField = if (properties.contains("inputField")) properties.getString("inputField", None) else None
 
@@ -37,12 +39,14 @@ class FirstValueOperator(properties: Map[String, JSerializable]) extends Operato
   override def processMap(inputFields: Map[String, JSerializable]): Option[Any] =
     if ((inputField.isDefined) && (inputFields.contains(inputField.get))) {
       Some(inputFields.get(inputField.get).get)
-    } else FirstValueOperator.SOME_EMPTY
+    } else FirstValueOperator.Some_Empty
 
   override def processReduce(values: Iterable[Option[Any]]): Option[Any] =
-    Try(values.head.orElse(FirstValueOperator.SOME_EMPTY)).getOrElse(FirstValueOperator.SOME_EMPTY)
+    Try(Some(transformValueByTypeOp(returnType, values.head.getOrElse(FirstValueOperator.Empty))))
+      .getOrElse(FirstValueOperator.Some_Empty)
 }
 
 private object FirstValueOperator {
-  val SOME_EMPTY = Some("")
+  val Some_Empty = Some("")
+  val Empty = ""
 }

--- a/plugins/operator-firstValue/src/test/scala/com/stratio/sparkta/plugin/operator/firstValue/FirstValueOperatorSpec.scala
+++ b/plugins/operator-firstValue/src/test/scala/com/stratio/sparkta/plugin/operator/firstValue/FirstValueOperatorSpec.scala
@@ -20,6 +20,8 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{Matchers, WordSpec}
 
+import com.stratio.sparkta.sdk.TypeOp
+
 @RunWith(classOf[JUnitRunner])
 class FirstValueOperatorSpec extends WordSpec with Matchers {
 
@@ -40,8 +42,11 @@ class FirstValueOperatorSpec extends WordSpec with Matchers {
       val inputFields = new FirstValueOperator(Map())
       inputFields.processReduce(Seq()) should be(Some(""))
 
-      val inputFields2 = new FirstValueOperator(Map())
-      inputFields2.processReduce(Seq(Some(1), Some(1))) should be(Some(1))
+      val inputFields2 = new FirstValueOperator(Map("typeOp" -> "int"))
+      inputFields2.processReduce(Seq(Some(1), Some(2))) should be(Some(1))
+
+      val inputFields4 = new FirstValueOperator(Map("typeOp" -> "string"))
+      inputFields4.processReduce(Seq(Some(1), Some(2))) should be(Some("1"))
 
       val inputFields3 = new FirstValueOperator(Map())
       inputFields3.processReduce(Seq(Some("a"), Some("b"))) should be(Some("a"))

--- a/plugins/operator-fullText/src/main/scala/com/stratio/sparkta/plugin/operator/fullText/FullTextOperator.scala
+++ b/plugins/operator-fullText/src/main/scala/com/stratio/sparkta/plugin/operator/fullText/FullTextOperator.scala
@@ -19,12 +19,14 @@ package com.stratio.sparkta.plugin.operator.fullText
 import java.io.{Serializable => JSerializable}
 import scala.util.Try
 
+import com.stratio.sparkta.sdk.TypeOp
+import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk.ValidatingPropertyMap._
 import com.stratio.sparkta.sdk._
 
 class FullTextOperator(properties: Map[String, JSerializable]) extends Operator(properties) {
 
-  override val typeOp = Some(TypeOp.String)
+  override val defaultTypeOperation = TypeOp.String
 
   private val inputField = if (properties.contains("inputField")) Some(properties.getString("inputField")) else None
 
@@ -39,7 +41,7 @@ class FullTextOperator(properties: Map[String, JSerializable]) extends Operator(
   }
 
   override def processReduce(values: Iterable[Option[Any]]): Option[String] = {
-    Try(Some(values.map(_.get.toString).reduce(_ + FullTextOperator.SEPARATOR + _)))
+    Try(Some(transformValueByTypeOp(returnType, values.map(_.get.toString).reduce(_ + FullTextOperator.SEPARATOR + _))))
       .getOrElse(FullTextOperator.SOME_EMPTY)
   }
 }

--- a/plugins/operator-fullText/src/test/scala/com/stratio/sparkta/plugin/operator/fullText/FullTextOperatorSpec.scala
+++ b/plugins/operator-fullText/src/test/scala/com/stratio/sparkta/plugin/operator/fullText/FullTextOperatorSpec.scala
@@ -45,6 +45,9 @@ class FullTextOperatorSpec extends WordSpec with Matchers {
 
       val inputFields3 = new FullTextOperator(Map())
       inputFields3.processReduce(Seq(Some("a"), Some("b"))) should be(Some(s"a${FullTextOperator.SEPARATOR}b"))
+
+      val inputFields4 = new FullTextOperator(Map("typeOp" -> "arraystring"))
+      inputFields4.processReduce(Seq(Some(1), Some(1))) should be(Some(Seq(s"1${FullTextOperator.SEPARATOR}1")))
     }
   }
 }

--- a/plugins/operator-lastValue/src/main/scala/com/stratio/sparkta/plugin/operator/lastValue/LastValueOperator.scala
+++ b/plugins/operator-lastValue/src/main/scala/com/stratio/sparkta/plugin/operator/lastValue/LastValueOperator.scala
@@ -19,12 +19,14 @@ package com.stratio.sparkta.plugin.operator.lastValue
 import java.io.{Serializable => JSerializable}
 import scala.util.Try
 
+import com.stratio.sparkta.sdk.TypeOp
+import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk.ValidatingPropertyMap._
 import com.stratio.sparkta.sdk._
 
 class LastValueOperator(properties: Map[String, JSerializable]) extends Operator(properties) {
 
-  override val typeOp = Some(TypeOp.String)
+  override val defaultTypeOperation = TypeOp.String
 
   private val inputField = if (properties.contains("inputField")) properties.getString("inputField", None) else None
 
@@ -37,12 +39,14 @@ class LastValueOperator(properties: Map[String, JSerializable]) extends Operator
   override def processMap(inputFields: Map[String, JSerializable]): Option[Any] =
     if ((inputField.isDefined) && (inputFields.contains(inputField.get))) {
       Some(inputFields.get(inputField.get).get)
-    } else LastValueOperator.SOME_EMPTY
+    } else LastValueOperator.Some_Empty
 
   override def processReduce(values: Iterable[Option[Any]]): Option[Any] =
-    Try(values.last.orElse(LastValueOperator.SOME_EMPTY)).getOrElse(LastValueOperator.SOME_EMPTY)
+    Try(Some(transformValueByTypeOp(returnType, values.last.getOrElse(LastValueOperator.Empty))))
+      .getOrElse(LastValueOperator.Some_Empty)
 }
 
 private object LastValueOperator {
-  val SOME_EMPTY = Some("")
+  val Some_Empty = Some("")
+  val Empty = ""
 }

--- a/plugins/operator-lastValue/src/test/scala/com/stratio/sparkta/plugin/operator/lastValue/LastValueOperatorSpec.scala
+++ b/plugins/operator-lastValue/src/test/scala/com/stratio/sparkta/plugin/operator/lastValue/LastValueOperatorSpec.scala
@@ -40,8 +40,11 @@ class LastValueOperatorSpec extends WordSpec with Matchers {
       val inputFields = new LastValueOperator(Map())
       inputFields.processReduce(Seq()) should be(Some(""))
 
-      val inputFields2 = new LastValueOperator(Map())
-      inputFields2.processReduce(Seq(Some(1), Some(1))) should be(Some(1))
+      val inputFields2 = new LastValueOperator(Map("typeOp" -> "int"))
+      inputFields2.processReduce(Seq(Some(1), Some(2))) should be(Some(2))
+
+      val inputFields4 = new LastValueOperator(Map("typeOp" -> "string"))
+      inputFields4.processReduce(Seq(Some(1), Some(2))) should be(Some("2"))
 
       val inputFields3 = new LastValueOperator(Map())
       inputFields3.processReduce(Seq(Some("a"), Some("b"))) should be(Some("b"))

--- a/plugins/operator-max/src/main/scala/com/stratio/sparkta/plugin/operator/max/MaxOperator.scala
+++ b/plugins/operator-max/src/main/scala/com/stratio/sparkta/plugin/operator/max/MaxOperator.scala
@@ -17,6 +17,8 @@
 package com.stratio.sparkta.plugin.operator.max
 
 import java.io.{Serializable => JSerializable}
+import com.stratio.sparkta.sdk.TypeOp
+import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk._
 import com.stratio.sparkta.sdk.ValidatingPropertyMap._
 
@@ -24,7 +26,7 @@ import scala.util.Try
 
 class MaxOperator(properties: Map[String, JSerializable]) extends Operator(properties) {
 
-  override val typeOp = Some(TypeOp.Double)
+  override val defaultTypeOperation = TypeOp.Double
 
   private val inputField = if(properties.contains("inputField")) Some(properties.getString("inputField")) else None
 
@@ -41,7 +43,7 @@ class MaxOperator(properties: Map[String, JSerializable]) extends Operator(prope
   }
 
   override def processReduce(values : Iterable[Option[Any]]): Option[Double] = {
-    Try(Some(values.flatten.map(_.asInstanceOf[Number].doubleValue()).max))
+    Try(Some(transformValueByTypeOp(returnType, values.flatten.map(_.asInstanceOf[Number].doubleValue()).max)))
       .getOrElse(MaxOperator.SOME_ZERO)
   }
 }

--- a/plugins/operator-max/src/test/scala/com/stratio/sparkta/plugin/operator/max/MaxOperatorSpec.scala
+++ b/plugins/operator-max/src/test/scala/com/stratio/sparkta/plugin/operator/max/MaxOperatorSpec.scala
@@ -61,6 +61,9 @@ class MaxOperatorSpec extends WordSpec with Matchers {
       val inputFields4 = new MaxOperator(Map())
       inputFields4.processReduce(Seq(None)) should be(Some(0d))
 
+      val inputFields5 = new MaxOperator(Map("typeOp" -> "string"))
+      inputFields5.processReduce(Seq(Some(1), Some(2))) should be(Some("2.0"))
+
     }
   }
 }

--- a/plugins/operator-median/src/main/scala/com/stratio/sparkta/plugin/operator/median/MedianOperator.scala
+++ b/plugins/operator-median/src/main/scala/com/stratio/sparkta/plugin/operator/median/MedianOperator.scala
@@ -19,6 +19,7 @@ import java.io.{Serializable => JSerializable}
 
 import scala.util.Try
 
+import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk.{TypeOp, WriteOp, Operator}
 import com.stratio.sparkta.sdk.ValidatingPropertyMap._
 import breeze.stats._
@@ -27,7 +28,7 @@ import breeze.linalg._
 
 class MedianOperator(properties: Map[String, JSerializable]) extends Operator(properties) {
 
-  override val typeOp = Some(TypeOp.Double)
+  override val defaultTypeOperation = TypeOp.Double
 
   private val inputField = if(properties.contains("inputField")) Some(properties.getString("inputField")) else None
 
@@ -46,8 +47,8 @@ class MedianOperator(properties: Map[String, JSerializable]) extends Operator(pr
   override def processReduce(values: Iterable[Option[Any]]): Option[Double] = {
     val valuesFiltered = values.flatten
     valuesFiltered.size match {
-      case (nz) if (nz != 0) =>
-        Some(median(DenseVector(valuesFiltered.map(_.asInstanceOf[Number].doubleValue()).toArray)))
+      case (nz) if (nz != 0) => Some(transformValueByTypeOp(returnType,
+        median(DenseVector(valuesFiltered.map(_.asInstanceOf[Number].doubleValue()).toArray))))
       case _ => MedianOperator.SOME_ZERO
     }
   }

--- a/plugins/operator-median/src/test/scala/com/stratio/sparkta/plugin/operator/median/MedianOperatorSpec.scala
+++ b/plugins/operator-median/src/test/scala/com/stratio/sparkta/plugin/operator/median/MedianOperatorSpec.scala
@@ -61,6 +61,9 @@ class MedianOperatorSpec extends WordSpec with Matchers {
       val inputFields4 = new MedianOperator(Map())
       inputFields4.processReduce(Seq(None)) should be(Some(0d))
 
+      val inputFields5 = new MedianOperator(Map("typeOp" -> "string"))
+      inputFields5.processReduce(Seq(Some(1), Some(2), Some(3), Some(7), Some(7))) should be(Some("3.0"))
+
     }
   }
 }

--- a/plugins/operator-min/src/main/scala/com/stratio/sparkta/plugin/operator/max/MinOperator.scala
+++ b/plugins/operator-min/src/main/scala/com/stratio/sparkta/plugin/operator/max/MinOperator.scala
@@ -17,6 +17,8 @@
 package com.stratio.sparkta.plugin.operator.min
 
 import java.io.{Serializable => JSerializable}
+import com.stratio.sparkta.sdk.TypeOp
+import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk._
 import com.stratio.sparkta.sdk.ValidatingPropertyMap._
 
@@ -24,7 +26,7 @@ import scala.util.Try
 
 class MinOperator(properties: Map[String, JSerializable]) extends Operator(properties) {
 
-  override val typeOp = Some(TypeOp.Double)
+  override val defaultTypeOperation = TypeOp.Double
 
   private val inputField = if(properties.contains("inputField")) Some(properties.getString("inputField")) else None
 
@@ -41,7 +43,7 @@ class MinOperator(properties: Map[String, JSerializable]) extends Operator(prope
   }
 
   override def processReduce(values : Iterable[Option[Any]]): Option[Double] = {
-    Try(Some(values.flatten.map(_.asInstanceOf[Number].doubleValue()).min))
+    Try(Some(transformValueByTypeOp(returnType, values.flatten.map(_.asInstanceOf[Number].doubleValue()).min)))
       .getOrElse(MinOperator.SOME_ZERO)
   }
 }

--- a/plugins/operator-min/src/test/scala/com/stratio/sparkta/plugin/operator/min/MinOperatorSpec.scala
+++ b/plugins/operator-min/src/test/scala/com/stratio/sparkta/plugin/operator/min/MinOperatorSpec.scala
@@ -53,13 +53,17 @@ class MinOperatorSpec extends WordSpec with Matchers {
       inputFields.processReduce(Seq()) should be(Some(0d))
 
       val inputFields2 = new MinOperator(Map())
-      inputFields2.processReduce(Seq(Some(1), Some(1))) should be(Some(1d))
+      inputFields2.processReduce(Seq(Some(1), Some(2))) should be(Some(1d))
 
       val inputFields3 = new MinOperator(Map())
       inputFields3.processReduce(Seq(Some(1), Some(2), Some(3))) should be(Some(1d))
 
       val inputFields4 = new MinOperator(Map())
       inputFields4.processReduce(Seq(None)) should be(Some(0d))
+
+      val inputFields5 = new MinOperator(Map("typeOp" -> "string"))
+      inputFields5.processReduce(Seq(Some(1), Some(2), Some(3), Some(7), Some(7))) should be(Some("1.0"))
+
 
     }
   }

--- a/plugins/operator-range/src/main/scala/com/stratio/sparkta/plugin/operator/range/RangeOperator.scala
+++ b/plugins/operator-range/src/main/scala/com/stratio/sparkta/plugin/operator/range/RangeOperator.scala
@@ -19,12 +19,13 @@ package com.stratio.sparkta.plugin.operator.range
 import java.io.{Serializable => JSerializable}
 import scala.util.Try
 
+import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk.{TypeOp, WriteOp, Operator}
 import com.stratio.sparkta.sdk.ValidatingPropertyMap._
 
 class RangeOperator(properties: Map[String, JSerializable]) extends Operator(properties) {
 
-  override val typeOp = Some(TypeOp.Double)
+  override val defaultTypeOperation = TypeOp.Double
 
   private val inputField = if (properties.contains("inputField")) Some(properties.getString("inputField")) else None
 
@@ -45,7 +46,7 @@ class RangeOperator(properties: Map[String, JSerializable]) extends Operator(pro
     valuesFiltered.size match {
       case (nz) if (nz != 0) => {
         val valuesConverted = valuesFiltered.map(_.asInstanceOf[Number].doubleValue())
-        Some(valuesConverted.max - valuesConverted.min)
+        Some(transformValueByTypeOp(returnType, valuesConverted.max - valuesConverted.min))
       }
       case _ => RangeOperator.SOME_ZERO
     }

--- a/plugins/operator-range/src/test/scala/com/stratio/sparkta/plugin/operator/avg/RangeOperatorSpec.scala
+++ b/plugins/operator-range/src/test/scala/com/stratio/sparkta/plugin/operator/avg/RangeOperatorSpec.scala
@@ -61,6 +61,8 @@ class RangeOperatorSpec extends WordSpec with Matchers {
       val inputFields4 = new RangeOperator(Map())
       inputFields4.processReduce(Seq(None)) should be(Some(0d))
 
+      val inputFields5 = new RangeOperator(Map("typeOp" -> "string"))
+      inputFields5.processReduce(Seq(Some(1), Some(2), Some(3), Some(7), Some(7))) should be(Some("6.0"))
     }
   }
 }

--- a/plugins/operator-stddev/src/main/scala/com/stratio/sparkta/plugin/operator/stddev/StddevOperator.scala
+++ b/plugins/operator-stddev/src/main/scala/com/stratio/sparkta/plugin/operator/stddev/StddevOperator.scala
@@ -20,6 +20,7 @@ import java.io.{Serializable => JSerializable}
 
 import scala.util.Try
 
+import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk.{TypeOp, WriteOp, Operator}
 import com.stratio.sparkta.sdk.ValidatingPropertyMap._
 import breeze.stats._
@@ -28,7 +29,7 @@ import breeze.linalg._
 
 class StddevOperator(properties: Map[String, JSerializable]) extends Operator(properties) {
 
-  override val typeOp = Some(TypeOp.Double)
+  override val defaultTypeOperation = TypeOp.Double
 
   private val inputField = if(properties.contains("inputField")) Some(properties.getString("inputField")) else None
 
@@ -47,7 +48,8 @@ class StddevOperator(properties: Map[String, JSerializable]) extends Operator(pr
   override def processReduce(values: Iterable[Option[Any]]): Option[Double] = {
     val valuesFiltered = values.flatten
     valuesFiltered.size match {
-      case (nz) if (nz != 0) => Some(stddev(valuesFiltered.map(_.asInstanceOf[Number].doubleValue())))
+      case (nz) if (nz != 0) =>
+        Some(transformValueByTypeOp(returnType, stddev(valuesFiltered.map(_.asInstanceOf[Number].doubleValue()))))
       case _ => StddevOperator.SOME_ZERO
     }
   }

--- a/plugins/operator-stddev/src/test/scala/com/stratio/sparkta/plugin/operator/stddev/StddevOperatorSpec.scala
+++ b/plugins/operator-stddev/src/test/scala/com/stratio/sparkta/plugin/operator/stddev/StddevOperatorSpec.scala
@@ -63,6 +63,11 @@ class StddevOperatorSpec extends WordSpec with Matchers {
       val inputFields4 = new StddevOperator(Map())
       inputFields4.processReduce(Seq(None)) should be(Some(0d))
 
+      val inputFields5 = new StddevOperator(Map("typeOp" -> "string"))
+      inputFields5.processReduce(
+        Seq(Some(1), Some(2), Some(3), Some(6.5), Some(7.5))) should be(Some("2.850438562747845"))
+
+
     }
   }
 }

--- a/plugins/operator-sum/src/main/scala/com/stratio/sparkta/plugin/operator/sum/SumOperator.scala
+++ b/plugins/operator-sum/src/main/scala/com/stratio/sparkta/plugin/operator/sum/SumOperator.scala
@@ -18,13 +18,14 @@ package com.stratio.sparkta.plugin.operator.sum
 
 import java.io.{Serializable => JSerializable}
 import scala.util.Try
+import com.stratio.sparkta.sdk.TypeOp._
 
 import com.stratio.sparkta.sdk.ValidatingPropertyMap._
 import com.stratio.sparkta.sdk._
 
 class SumOperator(properties: Map[String, JSerializable]) extends Operator(properties) {
 
-  override val typeOp = Some(TypeOp.Double)
+  override val defaultTypeOperation = TypeOp.Double
 
   private val inputField = if (properties.contains("inputField")) Some(properties.getString("inputField")) else None
 
@@ -41,8 +42,9 @@ class SumOperator(properties: Map[String, JSerializable]) extends Operator(prope
   }
 
   override def processReduce(values: Iterable[Option[Any]]): Option[Double] = {
-    Try(Some(values.flatten.map(_.asInstanceOf[Number].doubleValue()).reduce(_ + _)))
-      .getOrElse(SumOperator.SOME_ZERO)
+    Try(
+      Some(transformValueByTypeOp(returnType, values.flatten.map(_.asInstanceOf[Number].doubleValue()).reduce(_ + _)))
+    ).getOrElse(SumOperator.SOME_ZERO)
   }
 }
 

--- a/plugins/operator-sum/src/test/scala/com/stratio/sparkta/plugin/operator/sum/SumOperatorSpec.scala
+++ b/plugins/operator-sum/src/test/scala/com/stratio/sparkta/plugin/operator/sum/SumOperatorSpec.scala
@@ -62,6 +62,10 @@ class SumOperatorSpec extends WordSpec with Matchers {
       val inputFields4 = new SumOperator(Map())
       inputFields4.processReduce(Seq(None)) should be(Some(0d))
 
+      val inputFields5 = new SumOperator(Map("typeOp" -> "string"))
+      inputFields5.processReduce(Seq(Some(1), Some(2), Some(3))) should be(Some("6.0"))
+
+
 
     }
   }

--- a/plugins/operator-variance/src/main/scala/com/stratio/sparkta/plugin/operator/variance/VarianceOperator.scala
+++ b/plugins/operator-variance/src/main/scala/com/stratio/sparkta/plugin/operator/variance/VarianceOperator.scala
@@ -19,13 +19,14 @@ package com.stratio.sparkta.plugin.operator.variance
 import java.io.{Serializable => JSerializable}
 import scala.util.Try
 
+import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk.{TypeOp, WriteOp, Operator}
 import com.stratio.sparkta.sdk.ValidatingPropertyMap._
 import breeze.stats._
 
 class VarianceOperator(properties: Map[String, JSerializable]) extends Operator(properties) {
 
-  override val typeOp = Some(TypeOp.Double)
+  override val defaultTypeOperation = TypeOp.Double
 
   private val inputField = if(properties.contains("inputField")) Some(properties.getString("inputField")) else None
 
@@ -44,7 +45,8 @@ class VarianceOperator(properties: Map[String, JSerializable]) extends Operator(
   override def processReduce(values: Iterable[Option[Any]]): Option[Double] = {
     val valuesFiltered = values.flatten
     valuesFiltered.size match {
-      case (nz) if (nz != 0) => Some(variance(valuesFiltered.map(_.asInstanceOf[Number].doubleValue())))
+      case (nz) if (nz != 0) =>
+        Some(transformValueByTypeOp(returnType, variance(valuesFiltered.map(_.asInstanceOf[Number].doubleValue()))))
       case _ => VarianceOperator.SOME_ZERO
     }
   }

--- a/plugins/operator-variance/src/test/scala/com/stratio/sparkta/plugin/operator/variance/VarianceOperatorSpec.scala
+++ b/plugins/operator-variance/src/test/scala/com/stratio/sparkta/plugin/operator/variance/VarianceOperatorSpec.scala
@@ -61,6 +61,10 @@ class VarianceOperatorSpec extends WordSpec with Matchers {
       val inputFields4 = new VarianceOperator(Map())
       inputFields4.processReduce(Seq(None)) should be(Some(0d))
 
+      val inputFields5 = new VarianceOperator(Map("typeOp" -> "string"))
+      inputFields5.processReduce(Seq(Some(1), Some(2), Some(3), Some(7), Some(7))) should be(Some("8.0"))
+
+
     }
   }
 }

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/Bucketer.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/Bucketer.scala
@@ -18,7 +18,7 @@ package com.stratio.sparkta.sdk
 
 import java.io.{Serializable => JSerializable}
 
-import com.stratio.sparkta.sdk.TypeOp.TypeOp
+import com.stratio.sparkta.sdk.TypeOp._
 
 case class BucketType(id: String, typeOp: TypeOp, properties: Map[String, JSerializable]) {
 
@@ -27,7 +27,7 @@ case class BucketType(id: String, typeOp: TypeOp, properties: Map[String, JSeria
   }
 }
 
-trait Bucketer {
+trait Bucketer extends TypeConversions {
 
   /**
    * When writing to the cube at some address, the address will have one coordinate for each
@@ -40,8 +40,6 @@ trait Bucketer {
    */
   def bucket(value: JSerializable): Map[BucketType, JSerializable]
 
-  final val TypeOperationName = "typeOp"
-
   /**
    * All buckets supported into this bucketer
    *
@@ -51,44 +49,8 @@ trait Bucketer {
 
   def properties: Map[String, JSerializable] = Map()
 
-  def defaultTypeOperation: TypeOp = TypeOp.String
+  override def defaultTypeOperation: TypeOp = TypeOp.String
 
-  def getTypeOperation: Option[TypeOp] = getResultType(TypeOperationName)
-
-  def getTypeOperation(typeOperation: String): Option[TypeOp] =
-    if (!typeOperation.isEmpty && properties.contains(typeOperation)) getResultType(typeOperation)
-    else getResultType(TypeOperationName)
-
-  def getPrecision(precision: String, typeOperation: Option[TypeOp]): BucketType =
-    new BucketType(precision, typeOperation.getOrElse(defaultTypeOperation))
-
-  def getResultType(typeOperation: String): Option[TypeOp] =
-    if (!typeOperation.isEmpty) {
-      properties.get(typeOperation) match {
-        case Some(operation) => Some(getTypeOperationByName(operation.asInstanceOf[String]))
-        case None => None
-      }
-    } else None
-
-  //scalastyle:off
-  def getTypeOperationByName(nameOperation: String): TypeOp =
-    nameOperation.toLowerCase match {
-      case name if name == "bigdecimal" => TypeOp.BigDecimal
-      case name if name == "long" => TypeOp.Long
-      case name if name == "int" => TypeOp.Int
-      case name if name == "string" => TypeOp.String
-      case name if name == "double" => TypeOp.Double
-      case name if name == "boolean" => TypeOp.Boolean
-      case name if name == "binary" => TypeOp.Binary
-      case name if name == "date" => TypeOp.Date
-      case name if name == "datetime" => TypeOp.DateTime
-      case name if name == "timestamp" => TypeOp.Timestamp
-      case name if name == "arraydouble" => TypeOp.ArrayDouble
-      case name if name == "arraystring" => TypeOp.ArrayString
-      case _ => defaultTypeOperation
-    }
-
-  //scalastyle:on
 }
 
 object Bucketer {

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/DateOperations.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/DateOperations.scala
@@ -16,9 +16,12 @@
 
 package com.stratio.sparkta.sdk
 
+import java.io.{Serializable => JSerializable}
 import java.sql.Timestamp
+import java.util.Date
 
 import com.github.nscala_time.time.Imports._
+import org.joda.time.DateTime
 
 object DateOperations {
 
@@ -50,6 +53,13 @@ object DateOperations {
   }
 
   def millisToTimeStamp(date: Long): Timestamp = new Timestamp(date)
+
+  def getMillisFromSerializable(date: JSerializable): Long = date match {
+    case value if value.isInstanceOf[Timestamp] => value.asInstanceOf[Timestamp].getTime
+    case value if value.isInstanceOf[Date] => value.asInstanceOf[Date].getTime
+    case value if value.isInstanceOf[DateTime] => value.asInstanceOf[DateTime].getMillis
+    case _ => 0L
+  }
 
   def subPath(granularity: String, datePattern: Option[String]): String = {
     val suffix = dateFromGranularity(DateTime.now, granularity)

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/Operator.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/Operator.scala
@@ -23,9 +23,11 @@ import com.stratio.sparkta.sdk.TypeOp.TypeOp
 import com.stratio.sparkta.sdk.WriteOp.WriteOp
 
 abstract class Operator(properties: Map[String, JSerializable]) extends Parameterizable(properties)
-with Ordered[Operator] {
+with Ordered[Operator] with TypeConversions {
 
-  def typeOp: Option[TypeOp] = None
+  override def operationProps: Map[String, JSerializable] = properties
+
+  override def defaultTypeOperation: TypeOp = TypeOp.Binary
 
   def key: String
 
@@ -35,7 +37,7 @@ with Ordered[Operator] {
 
   def processReduce(values: Iterable[Option[Any]]): Option[Any]
 
-  def returnType: TypeOp = typeOp.getOrElse(TypeOp.Binary)
+  def returnType: TypeOp = getTypeOperation.getOrElse(defaultTypeOperation)
 
   def compare(operator: Operator): Int = key compareTo operator.key
 

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/TypeConversions.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/TypeConversions.scala
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparkta.sdk
+
+import java.io.{Serializable => JSerializable}
+
+import com.stratio.sparkta.sdk.TypeOp._
+
+trait TypeConversions {
+
+  final val TypeOperationName = "typeOp"
+
+  def defaultTypeOperation: TypeOp
+
+  def operationProps: Map[String, JSerializable] = Map()
+
+  def getTypeOperation: Option[TypeOp] = getResultType(TypeOperationName)
+
+  def getTypeOperation(typeOperation: String): Option[TypeOp] =
+    if (!typeOperation.isEmpty && operationProps.contains(typeOperation)) getResultType(typeOperation)
+    else getResultType(TypeOperationName)
+
+  def getPrecision(precision: String, typeOperation: Option[TypeOp]): BucketType =
+    new BucketType(precision, typeOperation.getOrElse(defaultTypeOperation))
+
+  def getResultType(typeOperation: String): Option[TypeOp] =
+    if (!typeOperation.isEmpty) {
+      operationProps.get(typeOperation) match {
+        case Some(operation) => Some(getTypeOperationByName(operation.asInstanceOf[String], defaultTypeOperation))
+        case None => None
+      }
+    } else None
+}

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/TypeOp.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/TypeOp.scala
@@ -27,63 +27,77 @@ object TypeOp extends Enumeration {
   val BigDecimal, Long, Int, String, Double, Boolean, Binary, Date, DateTime, Timestamp, ArrayDouble,
   ArrayString = Value
 
-  //scalastyle:off
   def transformValueByTypeOp[T](typeOp: TypeOp, origValue: T): T = {
     typeOp match {
-      case TypeOp.String => origValue match {
-        case value if value.isInstanceOf[String] => value
-        case value if value.isInstanceOf[Seq[Any]] =>
-          value.asInstanceOf[Seq[Any]].mkString(Output.Separator).asInstanceOf[T]
-        case _ => origValue.toString.asInstanceOf[T]
-      }
-      case TypeOp.ArrayDouble => origValue match {
-        case value if value.isInstanceOf[Seq[Double]] => value
-        case value if value.isInstanceOf[Seq[Any]] =>
-          Try(value.asInstanceOf[Seq[Any]].map(_.toString.toDouble)).getOrElse(Seq()).asInstanceOf[T]
-        case _ => Try(Seq(origValue.toString.toDouble)).getOrElse(Seq()).asInstanceOf[T]
-      }
-      case TypeOp.ArrayString => origValue match {
-        case value if value.isInstanceOf[Seq[String]] => value
-        case value if value.isInstanceOf[Seq[Any]] =>
-          Try(value.asInstanceOf[Seq[Any]].map(_.toString)).getOrElse(Seq()).asInstanceOf[T]
-        case _ => Try(Seq(origValue.toString)).getOrElse(Seq()).asInstanceOf[T]
-      }
-      case TypeOp.Timestamp => origValue match {
-        case value if value.isInstanceOf[Timestamp] => value
-        case value if value.isInstanceOf[Long] =>
-          DateOperations.millisToTimeStamp(value.asInstanceOf[Long]).asInstanceOf[T]
-        case value if value.isInstanceOf[Date] =>
-          DateOperations.millisToTimeStamp(value.asInstanceOf[Date].getTime).asInstanceOf[T]
-        case value if value.isInstanceOf[DateTime] =>
-          DateOperations.millisToTimeStamp(value.asInstanceOf[DateTime].getMillis).asInstanceOf[T]
-        case _ => Try(DateOperations.millisToTimeStamp(origValue.toString.toLong))
-          .getOrElse(DateOperations.millisToTimeStamp(0L)).asInstanceOf[T]
-      }
-      case TypeOp.Date => origValue match {
-        case value if value.isInstanceOf[Date] => value
-        case value if value.isInstanceOf[Long] => new Date(value.asInstanceOf[Long]).asInstanceOf[T]
-        case value if value.isInstanceOf[Date] => value.asInstanceOf[Date].asInstanceOf[T]
-        case value if value.isInstanceOf[DateTime] => value.asInstanceOf[DateTime].toDate.asInstanceOf[T]
-        case _ => Try(new Date(origValue.toString.toLong)).getOrElse(new Date(0L)).asInstanceOf[T]
-      }
-      case TypeOp.DateTime => origValue match {
-        case value if value.isInstanceOf[DateTime] => value
-        case value if value.isInstanceOf[Long] => new DateTime(value.asInstanceOf[Long]).asInstanceOf[T]
-        case value if value.isInstanceOf[Date] => new DateTime(value.asInstanceOf[Date]).asInstanceOf[T]
-        case value if value.isInstanceOf[DateTime] => value.asInstanceOf[DateTime].asInstanceOf[T]
-        case _ => Try(new DateTime(origValue.toString)).getOrElse(new DateTime(0L)).asInstanceOf[T]
-      }
-      case TypeOp.Long => origValue match {
-        case value if value.isInstanceOf[Long] => value
-        case value if value.isInstanceOf[Timestamp] => value.asInstanceOf[Timestamp].getTime.asInstanceOf[T]
-        case value if value.isInstanceOf[Date] => value.asInstanceOf[Date].getTime.asInstanceOf[T]
-        case value if value.isInstanceOf[DateTime] => value.asInstanceOf[Date].getTime.asInstanceOf[T]
-        case _ => Try(origValue.toString.toLong).getOrElse(0L).asInstanceOf[T]
-      }
+      case TypeOp.String => checkStringType(origValue)
+      case TypeOp.ArrayDouble => checkArrayDoubleType(origValue)
+      case TypeOp.ArrayString => checkArrayStringType(origValue)
+      case TypeOp.Timestamp => checkTimestampType(origValue)
+      case TypeOp.Date => checkDateType(origValue)
+      case TypeOp.DateTime => checkDateTimeType(origValue)
+      case TypeOp.Long => checkLongType(origValue)
       case _ => origValue
     }
   }
 
+  private def checkStringType[T](origValue : T) : T = origValue match {
+    case value if value.isInstanceOf[String] => value
+    case value if value.isInstanceOf[Seq[Any]] =>
+      value.asInstanceOf[Seq[Any]].mkString(Output.Separator).asInstanceOf[T]
+    case _ => origValue.toString.asInstanceOf[T]
+  }
+
+  private def checkArrayDoubleType[T](origValue : T) : T = origValue match {
+    case value if value.isInstanceOf[Seq[Double]] => value
+    case value if value.isInstanceOf[Seq[Any]] =>
+      Try(value.asInstanceOf[Seq[Any]].map(_.toString.toDouble)).getOrElse(Seq()).asInstanceOf[T]
+    case _ => Try(Seq(origValue.toString.toDouble)).getOrElse(Seq()).asInstanceOf[T]
+  }
+
+  private def checkArrayStringType[T](origValue : T) : T = origValue match {
+    case value if value.isInstanceOf[Seq[String]] => value
+    case value if value.isInstanceOf[Seq[Any]] =>
+      Try(value.asInstanceOf[Seq[Any]].map(_.toString)).getOrElse(Seq()).asInstanceOf[T]
+    case _ => Try(Seq(origValue.toString)).getOrElse(Seq()).asInstanceOf[T]
+  }
+
+  private def checkTimestampType[T](origValue : T) : T = origValue match {
+    case value if value.isInstanceOf[Timestamp] => value
+    case value if value.isInstanceOf[Long] =>
+      DateOperations.millisToTimeStamp(value.asInstanceOf[Long]).asInstanceOf[T]
+    case value if value.isInstanceOf[Date] =>
+      DateOperations.millisToTimeStamp(value.asInstanceOf[Date].getTime).asInstanceOf[T]
+    case value if value.isInstanceOf[DateTime] =>
+      DateOperations.millisToTimeStamp(value.asInstanceOf[DateTime].getMillis).asInstanceOf[T]
+    case _ => Try(DateOperations.millisToTimeStamp(origValue.toString.toLong))
+      .getOrElse(DateOperations.millisToTimeStamp(0L)).asInstanceOf[T]
+  }
+
+  private def checkDateType[T](origValue : T) : T = origValue match {
+    case value if value.isInstanceOf[Date] => value
+    case value if value.isInstanceOf[Long] => new Date(value.asInstanceOf[Long]).asInstanceOf[T]
+    case value if value.isInstanceOf[Date] => value.asInstanceOf[Date].asInstanceOf[T]
+    case value if value.isInstanceOf[DateTime] => value.asInstanceOf[DateTime].toDate.asInstanceOf[T]
+    case _ => Try(new Date(origValue.toString.toLong)).getOrElse(new Date(0L)).asInstanceOf[T]
+  }
+
+  private def checkDateTimeType[T](origValue : T) : T = origValue match {
+    case value if value.isInstanceOf[DateTime] => value
+    case value if value.isInstanceOf[Long] => new DateTime(value.asInstanceOf[Long]).asInstanceOf[T]
+    case value if value.isInstanceOf[Date] => new DateTime(value.asInstanceOf[Date]).asInstanceOf[T]
+    case value if value.isInstanceOf[DateTime] => value.asInstanceOf[DateTime].asInstanceOf[T]
+    case _ => Try(new DateTime(origValue.toString)).getOrElse(new DateTime(0L)).asInstanceOf[T]
+  }
+
+  private def checkLongType[T](origValue : T) : T = origValue match {
+    case value if value.isInstanceOf[Long] => value
+    case value if value.isInstanceOf[Timestamp] => value.asInstanceOf[Timestamp].getTime.asInstanceOf[T]
+    case value if value.isInstanceOf[Date] => value.asInstanceOf[Date].getTime.asInstanceOf[T]
+    case value if value.isInstanceOf[DateTime] => value.asInstanceOf[Date].getTime.asInstanceOf[T]
+    case _ => Try(origValue.toString.toLong).getOrElse(0L).asInstanceOf[T]
+  }
+
+  //scalastyle:off
   def getTypeOperationByName(nameOperation: String, defaultTypeOperation: TypeOp): TypeOp =
     nameOperation.toLowerCase match {
       case name if name == "bigdecimal" => TypeOp.BigDecimal

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/TypeOp.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/TypeOp.scala
@@ -16,7 +16,7 @@
 
 package com.stratio.sparkta.sdk
 
-import java.sql.Date
+import java.sql.{Timestamp, Date}
 import scala.util.Try
 
 import org.joda.time.DateTime
@@ -49,6 +49,7 @@ object TypeOp extends Enumeration {
         case _ => Try(Seq(origValue.toString)).getOrElse(Seq()).asInstanceOf[T]
       }
       case TypeOp.Timestamp => origValue match {
+        case value if value.isInstanceOf[Timestamp] => value
         case value if value.isInstanceOf[Long] =>
           DateOperations.millisToTimeStamp(value.asInstanceOf[Long]).asInstanceOf[T]
         case value if value.isInstanceOf[Date] =>
@@ -59,16 +60,25 @@ object TypeOp extends Enumeration {
           .getOrElse(DateOperations.millisToTimeStamp(0L)).asInstanceOf[T]
       }
       case TypeOp.Date => origValue match {
+        case value if value.isInstanceOf[Date] => value
         case value if value.isInstanceOf[Long] => new Date(value.asInstanceOf[Long]).asInstanceOf[T]
         case value if value.isInstanceOf[Date] => value.asInstanceOf[Date].asInstanceOf[T]
         case value if value.isInstanceOf[DateTime] => value.asInstanceOf[DateTime].toDate.asInstanceOf[T]
         case _ => Try(new Date(origValue.toString.toLong)).getOrElse(new Date(0L)).asInstanceOf[T]
       }
       case TypeOp.DateTime => origValue match {
+        case value if value.isInstanceOf[DateTime] => value
         case value if value.isInstanceOf[Long] => new DateTime(value.asInstanceOf[Long]).asInstanceOf[T]
         case value if value.isInstanceOf[Date] => new DateTime(value.asInstanceOf[Date]).asInstanceOf[T]
         case value if value.isInstanceOf[DateTime] => value.asInstanceOf[DateTime].asInstanceOf[T]
         case _ => Try(new DateTime(origValue.toString)).getOrElse(new DateTime(0L)).asInstanceOf[T]
+      }
+      case TypeOp.Long => origValue match {
+        case value if value.isInstanceOf[Long] => value
+        case value if value.isInstanceOf[Timestamp] => value.asInstanceOf[Timestamp].getTime.asInstanceOf[T]
+        case value if value.isInstanceOf[Date] => value.asInstanceOf[Date].getTime.asInstanceOf[T]
+        case value if value.isInstanceOf[DateTime] => value.asInstanceOf[Date].getTime.asInstanceOf[T]
+        case _ => Try(origValue.toString.toLong).getOrElse(0L).asInstanceOf[T]
       }
       case _ => origValue
     }


### PR DESCRIPTION
Description

Add a new trait for supervise the types defined in the policy. We use this implementation in two places, Bucketer that generate Dimensions and Operators. 

With this implementation we can return the type in three ways: 
1. Default.
2. TypeOp. Is a general tag that assign all with the same type. This has more priority than default.
3. Detail tag. Is a specifict tag that assign one type and this has more priority than TypeOp and default.

When return the value in the operators and dimensionsValues we control the type of the data with the new functions.


Reviewer
@arinconstrio 

Test
Some modifications in existing tests.

Scalastyle
All test passed.