### PR TITLE
wrong name in the fixture path

### DIFF
--- a/test-at/src/test/scala/com/stratio/sparkta/testat/ISocketOElasticsearchAT.scala
+++ b/test-at/src/test/scala/com/stratio/sparkta/testat/ISocketOElasticsearchAT.scala
@@ -33,7 +33,7 @@ import spray.http._
 class ISocketOElasticsearchAT extends SparktaATSuite{
 
   val PathToPolicy = getClass.getClassLoader.getResource("policies/ISocket-OElasticsearch.json").getPath
-  val PathToCsv = getClass.getClassLoader.getResource("fixtures/ISocket-OMongo.csv").getPath
+  val PathToCsv = getClass.getClassLoader.getResource("fixtures/at-data.csv").getPath
   val TimeElastisearchStarts: Long = 5000
   val PolicyEndSleep = 30000
   val ProductAAvg: Double = 750d


### PR DESCRIPTION
#### Description
Wrong name in the fixture path causes that the ISocketOElasticsearch.json fails.

#### Reviewer
@anistal 

#### Test
1 text fixed.

#### Scalastyle
All test passed.