### PR TITLE
A test fails because is comparing Seqs intead fo Sets

### DIFF
--- a/test-at/src/test/scala/com/stratio/sparkta/testat/ISocketOParquetAT.scala
+++ b/test-at/src/test/scala/com/stratio/sparkta/testat/ISocketOParquetAT.scala
@@ -38,7 +38,7 @@ class ISocketOParquetAT extends SparktaATSuite {
 
   implicit val formats = DefaultFormats + new JsoneyStringSerializer()
   val parquetPath = parse(Policy.openStream()).extract[AggregationPoliciesDto].outputs(0).configuration("path").toString
-  val expectedResults = Seq(("producta", 750.0D, 6000.0D),
+  val expectedResults = Set(("producta", 750.0D, 6000.0D),
     ("productb", 1000.0D, 8000.0D),
     ("producta", 750.0D, 6000.0D),
     ("productb", 1000.0D, 8000.0D))
@@ -72,7 +72,7 @@ class ISocketOParquetAT extends SparktaATSuite {
       val sqc = new SQLContext(sc)
       val result = sqc.parquetFile(parquetPath).toDF
       val elementsAsSeq = result.select("product", "avg_price", "sum_price").map(
-        row => (row.getString(0), row.getDouble(1), row.getDouble(2))).collect.toSeq
+        row => (row.getString(0), row.getDouble(1), row.getDouble(2))).collect.toSet
       elementsAsSeq should be(expectedResults)
     }
   }


### PR DESCRIPTION
#### Description
Tests are failing because they are checking that a Seq is the same that another Seq. The order of the elements could not be the same then the right data structure to use is a Map.

#### Reviewer
@sgomezg 

#### Test
1 acceptance test added. All passed

#### Scalastyle
All test passed.