### PR TITLE
Coverage plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -323,6 +323,24 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.scoverage</groupId>
+                <artifactId>scoverage-maven-plugin</artifactId>
+                <version>1.1.0</version>
+                <configuration>
+                    <scalaVersion>${scala.version}</scalaVersion>
+                    <aggregate>true</aggregate>
+                    <minimumCoverage>20</minimumCoverage>
+                    <failOnMinimumCoverage>false</failOnMinimumCoverage>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>

--- a/run_before_push.sh
+++ b/run_before_push.sh
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-mvn test 
+mvn scoverage:check scoverage:report


### PR DESCRIPTION
#### Description
Added scoverage plugin. It closes #304
Currently you can exec run_before_push.sh to do all stuff or, if you prefer, create a [git hook](https://gist.github.com/sgomezg/94c87a9f282be9d914b6)
SCoverage will create a file like [PROJECT]/target/site/scoverage/index.html

#### Reviewer
@anistal 

#### Test
No test added. All passed

#### Coverage
37,79 %. No changes

#### Scalastyle
All test passed.