### PR TITLE
Fixing paths to images in the readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Architecture
 Sparkta overview
 ------------
 
-![Settings Window](./doc/src/site/sphinx/images/sparkta1.png)
+![Architecture](./doc/src/site/sphinx/images/sparkta1.png)
 
 Key technologies
 ------------
@@ -95,7 +95,7 @@ Key technologies
 - [KiteSDK (morphlines)] (http://kitesdk.org/docs/current)
 
 
-![Settings Window](./doc/src/site/sphinx/images/Inoutputs.png)
+![Input/Outputs](./doc/src/site/sphinx/images/Inoutputs.png)
 
 Inputs
 ------------

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Architecture
 Sparkta overview
 ------------
 
-![Settings Window](https://github.com/Brezyll/sparkta/blob/master/doc/src/site/sphinx/images/sparkta1.png)
+![Settings Window](./doc/src/site/sphinx/images/sparkta1.png)
 
 Key technologies
 ------------
@@ -95,7 +95,7 @@ Key technologies
 - [KiteSDK (morphlines)] (http://kitesdk.org/docs/current)
 
 
-![Settings Window](https://github.com/Brezyll/sparkta/blob/feature/Doc/doc/src/site/sphinx/images/Inoutputs.png)
+![Settings Window](./doc/src/site/sphinx/images/Inoutputs.png)
 
 Inputs
 ------------


### PR DESCRIPTION
Simple fix in the images of the readme file:
- Using relative paths.
- Correct alt text.