### PR TITLE
fix run script & remove driver from relative path to find jars

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -30,7 +30,7 @@
         <plugins.directory>plugins</plugins.directory>
         <config.directory>src/main/resources</config.directory>
         <binary.name>sparkta-${project.version}</binary.name>
-        <driver.mainclass>com.stratio.sparkta.serving.api.driver.Sparkta</driver.mainclass>
+        <driver.mainclass>com.stratio.sparkta.serving.api.Sparkta</driver.mainclass>
         <outputFileName>stratio-sparkta</outputFileName>
     </properties>
     <dependencies>

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/constants/AppConstant.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/constants/AppConstant.scala
@@ -22,7 +22,7 @@ package com.stratio.sparkta.serving.api.constants
  */
 object AppConstant {
 
-  final val JarPaths = Seq("driver", "plugins", "sdk", "aggregator")
+  final val JarPaths = Seq( "plugins", "sdk", "aggregator")
   final val ConfigAppName = "sparkta"
   final val ConfigApi = "api"
   final val ConfigJobServer = "jobServer"


### PR DESCRIPTION
fixes 
 run script pointed to a wrong class
 we were trying to get jars from an non existing folder named driver at SPARKTA_HOME

#### Reviewer
@danielcsant 

#### Test
All  passed