### PR TITLE
fixed error related with only one input per policy

### DIFF
--- a/driver/src/main/scala/com/stratio/sparkta/driver/models/AggregationPoliciesModel.scala
+++ b/driver/src/main/scala/com/stratio/sparkta/driver/models/AggregationPoliciesModel.scala
@@ -33,7 +33,7 @@ case class AggregationPoliciesModel(name: String = "default",
                                   rawData: RawDataModel,
                                   transformations: Seq[TransformationsModel],
                                   cubes: Seq[CubeModel],
-                                  input: PolicyElementModel,
+                                  input: Option[PolicyElementModel] = None,
                                   outputs: Seq[PolicyElementModel],
                                   fragments: Seq[FragmentElementModel])
 

--- a/driver/src/main/scala/com/stratio/sparkta/driver/service/SparktaJob.scala
+++ b/driver/src/main/scala/com/stratio/sparkta/driver/service/SparktaJob.scala
@@ -125,8 +125,8 @@ object SparktaJob extends SLF4JLogging {
     }).toMap
 
   def input(apConfig: AggregationPoliciesModel, ssc: StreamingContext): (String, DStream[Event]) =
-      (apConfig.input.name, tryToInstantiate[Input](apConfig.input.`type` + Input.ClassSuffix, (c) =>
-        instantiateParameterizable[Input](c, apConfig.input.configuration)).setUp(ssc))
+      (apConfig.input.get.name, tryToInstantiate[Input](apConfig.input.get.`type` + Input.ClassSuffix, (c) =>
+        instantiateParameterizable[Input](c, apConfig.input.get.configuration)).setUp(ssc))
 
   def parsers(apConfig: AggregationPoliciesModel): Seq[Parser] =
     apConfig.transformations.map(parser =>
@@ -230,7 +230,7 @@ object SparktaJob extends SLF4JLogging {
     }
 
   def jarsFromPolicy(apConfig: AggregationPoliciesModel): Seq[String] = {
-    val input = apConfig.input.jarFile match {
+    val input = apConfig.input.get.jarFile match {
       case Some(file) => Seq(file)
       case None => Seq()
     }

--- a/driver/src/test/scala/com/stratio/sparkta/driver/test/models/AggregationPoliciesSpec.scala
+++ b/driver/src/test/scala/com/stratio/sparkta/driver/test/models/AggregationPoliciesSpec.scala
@@ -58,7 +58,7 @@ with Matchers {
         rawDataDto,
         Seq(),
         Seq(cubeDto),
-        input,
+        Some(input),
         Seq(mock[PolicyElementModel]),
         Seq(mock[FragmentElementModel]))
 
@@ -74,7 +74,7 @@ with Matchers {
         rawDataDto,
         Seq(),
         Seq(cubeDto),
-        input,
+        Some(input),
         Seq(mock[PolicyElementModel]),
         Seq(mock[FragmentElementModel]))
 

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/ClusterContextActor.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/ClusterContextActor.scala
@@ -119,7 +119,7 @@ class ClusterContextActor(policy: AggregationPoliciesModel,
         jobServerRef ! new JsUploadPolicy("driver-plugin.jar",
           "com.stratio.sparkta.driver.service.SparktaJob",
           policyStr,
-          Some(s"${policy.name}-${policy.input.name}"))
+          Some(s"${policy.name}-${policy.input.get.name}"))
     }
   }
 

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/helpers/PolicyHelper.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/helpers/PolicyHelper.scala
@@ -46,12 +46,11 @@ object PolicyHelper {
         case FragmentType.input => FragmentType.input -> fragment.element
         case FragmentType.output => FragmentType.output -> fragment.element
       })
-      ++ Map(FragmentType.input -> apConfig.input)
       ++ apConfig.outputs.map(output => FragmentType.output -> output)
       ).groupBy(_._1).mapValues(_.map(_._2))
 
     apConfig.copy(
-      input = mapInputsOutputs.getOrElse(FragmentType.input, Seq()).head,
+      input = Some(getCurrentInput(mapInputsOutputs, apConfig)),
       outputs = mapInputsOutputs.getOrElse(FragmentType.output, Seq()))
   }
 
@@ -62,16 +61,14 @@ object PolicyHelper {
    * @return a fragment with all fields filled.
    */
   def fillFragments(apConfig: AggregationPoliciesModel,
-                            actor: ActorRef,
-                            currentTimeout: Timeout): AggregationPoliciesModel = {
-
+                    actor: ActorRef,
+                    currentTimeout: Timeout): AggregationPoliciesModel = {
     implicit val timeout = currentTimeout
 
     val currentFragments: Seq[FragmentElementModel] = apConfig.fragments.map(fragment => {
       val future = actor ? new FragmentSupervisorActor_findByTypeAndName(fragment.fragmentType, fragment.name)
       Await.result(future, timeout.duration) match {
         case FragmentSupervisorActor_response_fragment(Failure(exception)) => {
-          exception.printStackTrace()
           throw exception
         }
         case FragmentSupervisorActor_response_fragment(Success(fragment)) => fragment
@@ -79,4 +76,28 @@ object PolicyHelper {
     })
     apConfig.copy(fragments = currentFragments)
   }
+
+  //////////////////////////////////////////// PRIVATE METHODS /////////////////////////////////////////////////////////
+
+  /**
+   * Depending of where is the input it tries to get a input. If not an exceptions is trowed.
+   * @param mapInputsOutputs with inputs/outputs extracted from the fragments.
+   * @param apConfig with the current configuration.
+   * @return A policyElementModel with the input.
+   */
+  private def getCurrentInput(mapInputsOutputs: Map[`type`, Seq[PolicyElementModel]],
+                              apConfig: AggregationPoliciesModel): PolicyElementModel = {
+    val currentInputs = mapInputsOutputs.filter(x => if(x._1 == FragmentType.input) true else false)
+
+    if(currentInputs.size > 1 || (currentInputs.size == 1 && apConfig.input.isDefined)) {
+      throw new IllegalStateException("Only one input is allowed in the policy.")
+    }
+
+    if(currentInputs.size == 0 && apConfig.input.isDefined == false) {
+      throw new IllegalStateException("It is mandatory to define at least one input in the policy.")
+    }
+
+    if(apConfig.input.isDefined) apConfig.input.get else mapInputsOutputs.get(FragmentType.input).get.head
+  }
+
 }

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/helpers/PolicyHelper.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/helpers/PolicyHelper.scala
@@ -89,15 +89,16 @@ object PolicyHelper {
                               apConfig: AggregationPoliciesModel): PolicyElementModel = {
     val currentInputs = mapInputsOutputs.filter(x => if(x._1 == FragmentType.input) true else false)
 
-    if(currentInputs.size > 1 || (currentInputs.size == 1 && apConfig.input.isDefined)) {
+    if((currentInputs.nonEmpty && currentInputs.get(FragmentType.input).get.size > 1)
+      ||(currentInputs.nonEmpty && currentInputs.get(FragmentType.input).get.size == 1 && apConfig.input.isDefined)) {
       throw new IllegalStateException("Only one input is allowed in the policy.")
     }
 
-    if(currentInputs.size == 0 && apConfig.input.isDefined == false) {
+    if(currentInputs.isEmpty && apConfig.input.isDefined == false) {
       throw new IllegalStateException("It is mandatory to define at least one input in the policy.")
     }
 
-    if(apConfig.input.isDefined) apConfig.input.get else mapInputsOutputs.get(FragmentType.input).get.head
+    apConfig.input.getOrElse(mapInputsOutputs.get(FragmentType.input).get.head)
   }
 
 }

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/helpers/PolicyHelper.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/helpers/PolicyHelper.scala
@@ -80,7 +80,7 @@ object PolicyHelper {
   //////////////////////////////////////////// PRIVATE METHODS /////////////////////////////////////////////////////////
 
   /**
-   * Depending of where is the input it tries to get a input. If not an exceptions is trowed.
+   * Depending of where is the input it tries to get a input. If not an exceptions is thrown.
    * @param mapInputsOutputs with inputs/outputs extracted from the fragments.
    * @param apConfig with the current configuration.
    * @return A policyElementModel with the input.

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/service/http/PolicyHttpService.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/service/http/PolicyHttpService.scala
@@ -137,8 +137,8 @@ trait PolicyHttpService extends BaseHttpService {
     path(HttpConstant.PolicyPath) {
       post {
         entity(as[AggregationPoliciesModel]) { policy =>
-          val parsedP = PolicyHelper.fillFragments(
-            PolicyHelper.parseFragments(policy),actors.get(AkkaConstant.FragmentActor).get, timeout)
+          val parsedP = PolicyHelper.parseFragments(
+            PolicyHelper.fillFragments(policy,actors.get(AkkaConstant.FragmentActor).get, timeout))
           val isValidAndMessageTuple = AggregationPoliciesValidator.validateDto(parsedP)
           validate(isValidAndMessageTuple._1, isValidAndMessageTuple._2)
           complete {
@@ -228,9 +228,8 @@ trait PolicyHttpService extends BaseHttpService {
         Await.result(future, timeout.duration) match {
           case PolicySupervisorActor_response_policy(Failure(exception)) => throw exception
           case PolicySupervisorActor_response_policy(Success(policy)) => {
-            val parsedP =
-              PolicyHelper.parseFragments(PolicyHelper.fillFragments(
-                policy,actors.get(AkkaConstant.FragmentActor).get, timeout))
+            val parsedP = PolicyHelper.parseFragments(
+              PolicyHelper.fillFragments(policy,actors.get(AkkaConstant.FragmentActor).get, timeout))
             val isValidAndMessageTuple = AggregationPoliciesValidator.validateDto(parsedP)
             validate(isValidAndMessageTuple._1, isValidAndMessageTuple._2) {
               actors.get("streamingActor").get ! new CreateContext(parsedP)

--- a/serving-api/src/test/scala/com/stratio/sparkta/serving/api/test/helpers/PolicyHelperSpec.scala
+++ b/serving-api/src/test/scala/com/stratio/sparkta/serving/api/test/helpers/PolicyHelperSpec.scala
@@ -45,7 +45,7 @@ class PolicyHelperSpec extends FeatureSpec with GivenWhenThen with Matchers {
         new RawDataModel(),
         transformations = Seq(),
         cubes = Seq(),
-        input = PolicyElementModel("input1", "input", Map()),
+        input = None,
         outputs = Seq(
           PolicyElementModel("output1", "output", Map())),
         fragments = Seq(
@@ -64,7 +64,7 @@ class PolicyHelperSpec extends FeatureSpec with GivenWhenThen with Matchers {
 
       Then("outputs must have the existing outputs and the parsed input fragment and the first input")
 
-      result.input should equal(PolicyElementModel("inputF", "input", Map()))
+      result.input should equal(Some(PolicyElementModel("inputF", "input", Map())))
 
       result.outputs.toSet should equal(Seq(
         PolicyElementModel("output1", "output", Map()),
@@ -72,4 +72,41 @@ class PolicyHelperSpec extends FeatureSpec with GivenWhenThen with Matchers {
       )
     }
   }
+
+  scenario("A policy that contains one input an a fragments with one input too must throw an exception because only " +
+    "one input is allowed") {
+
+    Given("a policy with an input, an output and a fragment with an input")
+    val checkpointDir = "checkpoint"
+
+    val ap = new AggregationPoliciesModel(
+      "policy-test",
+      sparkStreamingWindow = 2000,
+      checkpointDir,
+      new RawDataModel(),
+      transformations = Seq(),
+      cubes = Seq(),
+      input = Some(PolicyElementModel("input1", "input", Map())),
+      outputs = Seq(
+        PolicyElementModel("output1", "output", Map())),
+      fragments = Seq(
+        FragmentElementModel(
+          name = "fragment1",
+          fragmentType = "input",
+          element = PolicyElementModel("inputF", "input", Map())),
+        FragmentElementModel(
+          name = "fragment1",
+          fragmentType = "output",
+          element = PolicyElementModel("outputF", "output", Map())))
+    )
+
+    When("the helper tries to parse the policy it throws an exception")
+    val thrown = intercept[IllegalStateException] {
+      PolicyHelper.parseFragments(ap)
+    }
+
+    Then("the exception must have the message")
+    assert(thrown.getMessage === "Only one input is allowed in the policy.")
+  }
+
 }

--- a/serving-api/src/test/scala/com/stratio/sparkta/serving/api/test/route/PolicyRoutesSpec.scala
+++ b/serving-api/src/test/scala/com/stratio/sparkta/serving/api/test/route/PolicyRoutesSpec.scala
@@ -92,7 +92,7 @@ with Matchers {
     "Create policy" in {
       val PolicyName = "p-1"
       val apd = new AggregationPoliciesModel(PolicyName, sparkStreamingWindow, checkpointDir, new RawDataModel(),
-        Seq(), Seq(), input, Seq(), Seq())
+        Seq(), Seq(), Some(input), Seq(), Seq())
       try {
         val test = Post("/policy", apd) ~> routes
         supervisorProbe.expectMsg(new CreateContext(apd))
@@ -128,7 +128,7 @@ with Matchers {
         new CheckpointModel(checkpointGranularity, checkpointGranularity, checkpointInterval, checkpointAvailable)
       val cubeDto = new CubeModel(cubeName, checkpointConfig, Seq(dimensionDto), Seq(), CubeModel.Multiplexer)
       val apd = new AggregationPoliciesModel(PolicyName, sparkStreamingWindow, checkpointDir, new RawDataModel(),
-        Seq(), Seq(cubeDto), input, Seq(), Seq())
+        Seq(), Seq(cubeDto), Some(input), Seq(), Seq())
       val test = Post("/policy", apd) ~> routes
       test ~> check {
         rejections.size should be(1)


### PR DESCRIPTION
#### Description
There is an error parsing policies when the input is in a fragment.

It closes #507 

#### Reviewer
@antonioalf    

#### Test
One scenario added to PolicyHelperSpec.scala