### PR TITLE
Spark upgrade to 1.4.1

### DIFF
--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -54,6 +54,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.stratio.sparkta</groupId>
             <artifactId>field-default</artifactId>
             <version>${project.version}</version>

--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -85,6 +85,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.scalamock</groupId>
             <artifactId>scalamock-scalatest-support_2.10</artifactId>
             <version>3.2.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <maven.compiler.target>1.7</maven.compiler.target>
         <scala.binary.version>2.10</scala.binary.version>
         <scala.version>2.10.4</scala.version>
-        <spark.version>1.4.0</spark.version>
+        <spark.version>1.4.1</spark.version>
         <slf4j.version>1.7.7</slf4j.version>
         <nscala.time.version>2.0.0</nscala.time.version>
         <scalatest.version>2.2.2</scalatest.version>
@@ -218,6 +218,12 @@
             <dependency>
                 <groupId>org.apache.spark</groupId>
                 <artifactId>spark-streaming_${scala.binary.version}</artifactId>
+                <version>${spark.version}</version>
+                <classifier>tests</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.spark</groupId>
+                <artifactId>spark-core_${scala.binary.version}</artifactId>
                 <version>${spark.version}</version>
                 <classifier>tests</classifier>
             </dependency>


### PR DESCRIPTION
#### Description
Spark upgrade to 1.4.1. It closes #446

#### Reviewer
@danielcsant 

#### Test
No changes

#### Coverage
No changes

#### Scalastyle
No info