### PR TITLE
Refactor of MongoDB output

### DIFF
--- a/plugins/output-mongodb/src/main/scala/com/stratio/sparkta/plugin/output/mongodb/MongoDbOutput.scala
+++ b/plugins/output-mongodb/src/main/scala/com/stratio/sparkta/plugin/output/mongodb/MongoDbOutput.scala
@@ -45,18 +45,18 @@ class MongoDbOutput(keyName: String,
 
   override val isAutoCalculateId = true
 
+
   override val hosts = properties.getString("hosts", "localhost")
 
   val mongoDbDataFrameConnection = hosts.replaceAll("mongodb://", "")
 
   override val dbName = properties.getString("dbName", "sparkta")
 
-  override val connectionsPerHost = Try(properties.getInt("connectionsPerHost")).getOrElse(DefaultConnectionsPerHost)
+  override val connectionsPerHost = properties.getString("connectionsPerHost", DefaultConnectionsPerHost).toInt
 
-  override val threadsAllowedB = Try(properties.getInt("threadsAllowedToBlock"))
-    .getOrElse(DefaultThreadsAllowedToBlock)
+  override val threadsAllowedB = properties.getString("threadsAllowedToBlock", DefaultThreadsAllowedToBlock).toInt
 
-  override val retrySleep = Try(properties.getInt("retrySleep")).getOrElse(DefaultRetrySleep)
+  override val retrySleep = properties.getString("retrySleep", DefaultRetrySleep).toInt
 
   override val idAsField = Try(properties.getString("idAsField").toBoolean).getOrElse(false)
 

--- a/plugins/output-mongodb/src/main/scala/com/stratio/sparkta/plugin/output/mongodb/dao/MongoDbDAO.scala
+++ b/plugins/output-mongodb/src/main/scala/com/stratio/sparkta/plugin/output/mongodb/dao/MongoDbDAO.scala
@@ -35,9 +35,9 @@ import org.joda.time.DateTime
 
 trait MongoDbDAO extends Closeable {
 
-  final val DefaultConnectionsPerHost = 5
-  final val DefaultThreadsAllowedToBlock = 10
-  final val DefaultRetrySleep = 1000
+  final val DefaultConnectionsPerHost = "5"
+  final val DefaultThreadsAllowedToBlock = "10"
+  final val DefaultRetrySleep = "1000"
   final val LanguageFieldName = "language"
   final val DefaultId = "_id"
   final val DefaultWriteConcern = casbah.WriteConcern.Unacknowledged


### PR DESCRIPTION
#### Description
Now all the MongoDB fields of the policy are strings

#### Test
All passed

#### Coverage
No changes

#### Scalastyle
No info