### PR TITLE
Remove default name

### DIFF
--- a/serving-core/src/main/scala/com/stratio/sparkta/serving/core/models/AggregationPoliciesModel.scala
+++ b/serving-core/src/main/scala/com/stratio/sparkta/serving/core/models/AggregationPoliciesModel.scala
@@ -27,7 +27,7 @@ import org.json4s.jackson.JsonMethods._
 
 case class AggregationPoliciesModel(id: Option[String] = None,
                                     storageLevel: Option[String] = AggregationPoliciesModel.storageDefaultValue,
-                                    name: String = "default",
+                                    name: String,
                                     description: String = "default description",
                                     sparkStreamingWindow: Long = AggregationPoliciesModel.sparkStreamingWindow,
                                     checkpointPath: String,


### PR DESCRIPTION
Before, If we didn't specify the name, the policyContext was created with a default name. Now, the name is mandatory.