### PR TITLE
Added status to response in findAll method

### DIFF
--- a/serving-core/src/main/scala/com/stratio/sparkta/serving/core/policy/status/PolicyStatusActor.scala
+++ b/serving-core/src/main/scala/com/stratio/sparkta/serving/core/policy/status/PolicyStatusActor.scala
@@ -145,4 +145,5 @@ object PolicyStatusEnum extends Enumeration {
   val Failed = Value("Failed")
   val Stopping = Value("Stopping")
   val Stopped = Value("Stopped")
+  val NotStarted = Value("NotStarted")
 }


### PR DESCRIPTION
#### Description
Added mandatory fields with the annotation called required

Now, the endpoint returns the status of the policy. Now, the response is like this:
```javascript
[
  {
    "status": "Failed",
    "policy": {
      "id": "id",
      "storageLevel": "MEMORY_AND_DISK_SER_1",
       ....
    },
  },
  ...
  {
    "status": "NotStarted",
    "policy": {
      "id": "id2",
      "storageLevel": "MEMORY_AND_DISK_SER_2",
       ....
    }
  }
]
```
If the policy doesn't have status, NotStarted will be shown.


#### Test
All passed.

#### Coverage
No changes

#### Scalastyle
No info