### PR TITLE
Policies validation and returned values with fragments

### DIFF
--- a/serving-api/src/main/resources/policy_schema.json
+++ b/serving-api/src/main/resources/policy_schema.json
@@ -6,7 +6,6 @@
     "transformations": {
       "id": "http://sparkta.stratio.com/transformations",
       "type": "array",
-      "uniqueItems": true,
       "items": {
         "id": "http://sparkta.stratio.com/transformations/",
         "type": "object",
@@ -27,7 +26,6 @@
             "id": "http://sparkta.stratio.com/transformations/outputFields",
             "type": "array",
             "minItems": 1,
-            "uniqueItems": true,
             "items": {
               "id": "http://sparkta.stratio.com/transformations/outputFields/",
               "type": "string"
@@ -113,7 +111,6 @@
       "id": "http://sparkta.stratio.com/cubes",
       "type": "array",
       "minItems": 1,
-      "uniqueItems": true,
       "items": {
         "id": "http://sparkta.stratio.com/cubes/",
         "type": "object",
@@ -154,7 +151,6 @@
             "id": "http://sparkta.stratio.com/cubes/dimensions",
             "type": "array",
             "minItems": 1,
-            "uniqueItems": true,
             "items": [
               {
                 "id": "http://sparkta.stratio.com/cubes/dimensions/",
@@ -187,7 +183,6 @@
           "operators": {
             "id": "http://sparkta.stratio.com/cubes/operators",
             "type": "array",
-            "uniqueItems": true,
             "items": {
               "id": "http://sparkta.stratio.com/cubes/operators/",
               "type": "object",
@@ -223,7 +218,6 @@
       "id": "http://sparkta.stratio.com/outputs",
       "type": "array",
       "minItems": 1,
-      "uniqueItems": true,
       "items": {
         "id": "http://sparkta.stratio.com/outputs/",
         "type": "object",
@@ -250,7 +244,6 @@
     "fragments": {
       "id": "http://sparkta.stratio.com/fragments",
       "type": "array",
-      "uniqueItems": true,
       "items": {
         "id": "http://sparkta.stratio.com/fragments/",
         "type": "object",

--- a/serving-api/src/main/resources/policy_schema.json
+++ b/serving-api/src/main/resources/policy_schema.json
@@ -6,7 +6,6 @@
     "transformations": {
       "id": "http://sparkta.stratio.com/transformations",
       "type": "array",
-      "minItems": 1,
       "uniqueItems": true,
       "items": {
         "id": "http://sparkta.stratio.com/transformations/",
@@ -116,7 +115,7 @@
       "minItems": 1,
       "uniqueItems": true,
       "items": {
-        "id": "http://sparkta.stratio.com/cubes/0",
+        "id": "http://sparkta.stratio.com/cubes/",
         "type": "object",
         "properties": {
           "name": {

--- a/serving-api/src/main/resources/policy_schema.json
+++ b/serving-api/src/main/resources/policy_schema.json
@@ -246,6 +246,34 @@
           "type"
         ]
       }
+    },
+    "fragments": {
+      "id": "http://sparkta.stratio.com/fragments",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "id": "http://sparkta.stratio.com/fragments/",
+        "type": "object",
+        "properties": {
+          "id": {
+            "id": "http://sparkta.stratio.com/fragments/id",
+            "type": "string"
+          },
+          "fragmentType": {
+            "id": "http://sparkta.stratio.com/fragments/fragmentType",
+            "type": "string"
+          },
+          "name": {
+            "id": "http://sparkta.stratio.com/fragments/name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "fragmentType",
+          "name"
+        ]
+      }
     }
   },
   "required": [

--- a/serving-api/src/main/resources/policy_schema.json
+++ b/serving-api/src/main/resources/policy_schema.json
@@ -259,12 +259,22 @@
           "name": {
             "id": "http://sparkta.stratio.com/fragments/name",
             "type": "string"
+          },
+          "description": {
+            "id": "http://sparkta.stratio.com/fragments/description",
+            "type": "string"
+          },
+          "shortDescription": {
+            "id": "http://sparkta.stratio.com/fragments/shortDescription",
+            "type": "string"
           }
         },
         "required": [
           "id",
           "fragmentType",
-          "name"
+          "name",
+          "shortDescription",
+          "description"
         ]
       }
     }

--- a/serving-api/src/main/resources/policy_schema.json
+++ b/serving-api/src/main/resources/policy_schema.json
@@ -3,8 +3,63 @@
   "id": "http://sparkta.stratio.com",
   "type": "object",
   "properties": {
+    "transformations": {
+      "id": "http://sparkta.stratio.com/transformations",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "id": "http://sparkta.stratio.com/transformations/",
+        "type": "object",
+        "properties": {
+          "name": {
+            "id": "http://sparkta.stratio.com/transformations/name",
+            "type": "string"
+          },
+          "order": {
+            "id": "http://sparkta.stratio.com/transformations/order",
+            "type": "integer"
+          },
+          "inputField": {
+            "id": "http://sparkta.stratio.com/transformations/inputField",
+            "type": "string"
+          },
+          "outputFields": {
+            "id": "http://sparkta.stratio.com/transformations/outputFields",
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "id": "http://sparkta.stratio.com/transformations/outputFields/",
+              "type": "string"
+            }
+          },
+          "type": {
+            "id": "http://sparkta.stratio.com/transformations/type",
+            "type": "string"
+          },
+          "configuration": {
+            "id": "http://sparkta.stratio.com/transformations/configuration",
+            "type": "object"
+          }
+        },
+        "required": [
+          "name",
+          "order",
+          "outputFields"
+        ]
+      }
+    },
+    "description": {
+      "id": "http://sparkta.stratio.com/description",
+      "type": "string"
+    },
     "name": {
       "id": "http://sparkta.stratio.com/name",
+      "type": "string"
+    },
+    "storageLevel": {
+      "id": "http://sparkta.stratio.com/storageLevel",
       "type": "string"
     },
     "sparkStreamingWindow": {
@@ -14,6 +69,24 @@
     "checkpointPath": {
       "id": "http://sparkta.stratio.com/checkpointPath",
       "type": "string"
+    },
+    "rawData": {
+      "id": "http://sparkta.stratio.com/rawData",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "id": "http://sparkta.stratio.com/rawData/enabled",
+          "type": "string"
+        },
+        "partitionFormat": {
+          "id": "http://sparkta.stratio.com/rawData/partitionFormat",
+          "type": "string"
+        },
+        "path": {
+          "id": "http://sparkta.stratio.com/rawData/path",
+          "type": "string"
+        }
+      }
     },
     "input": {
       "id": "http://sparkta.stratio.com/input",
@@ -26,8 +99,16 @@
         "type": {
           "id": "http://sparkta.stratio.com/input/type",
           "type": "string"
+        },
+        "configuration": {
+          "id": "http://sparkta.stratio.com/input/configuration",
+          "type": "object"
         }
-      }
+      },
+      "required": [
+        "name",
+        "type"
+      ]
     },
     "cubes": {
       "id": "http://sparkta.stratio.com/cubes",
@@ -35,27 +116,142 @@
       "minItems": 1,
       "uniqueItems": true,
       "items": {
-        "id": "auto-generated-schema-246"
+        "id": "http://sparkta.stratio.com/cubes/0",
+        "type": "object",
+        "properties": {
+          "name": {
+            "id": "http://sparkta.stratio.com/cubes/name",
+            "type": "string"
+          },
+          "checkpointConfig": {
+            "id": "http://sparkta.stratio.com/cubes/checkpointConfig",
+            "type": "object",
+            "properties": {
+              "timeDimension": {
+                "id": "http://sparkta.stratio.com/cubes/checkpointConfig/timeDimension",
+                "type": "string"
+              },
+              "granularity": {
+                "id": "http://sparkta.stratio.com/cubes/checkpointConfig/granularity",
+                "type": "string"
+              },
+              "interval": {
+                "id": "http://sparkta.stratio.com/cubes/checkpointConfig/interval",
+                "type": "integer"
+              },
+              "timeAvailability": {
+                "id": "http://sparkta.stratio.com/cubes/checkpointConfig/timeAvailability",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "timeDimension",
+              "granularity",
+              "interval",
+              "timeAvailability"
+            ]
+          },
+          "dimensions": {
+            "id": "http://sparkta.stratio.com/cubes/dimensions",
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": [
+              {
+                "id": "http://sparkta.stratio.com/cubes/dimensions/",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "id": "http://sparkta.stratio.com/cubes/dimensions/name",
+                    "type": "string"
+                  },
+                  "field": {
+                    "id": "http://sparkta.stratio.com/cubes/dimensions/field",
+                    "type": "string"
+                  },
+                  "type": {
+                    "id": "http://sparkta.stratio.com/cubes/dimensions/type",
+                    "type": "string"
+                  },
+                  "precision": {
+                    "id": "http://sparkta.stratio.com/cubes/dimensions/precision",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "field"
+                ]
+              }
+            ]
+          },
+          "operators": {
+            "id": "http://sparkta.stratio.com/cubes/operators",
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+              "id": "http://sparkta.stratio.com/cubes/operators/",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "id": "http://sparkta.stratio.com/cubes/operators/name",
+                  "type": "string"
+                },
+                "type": {
+                  "id": "http://sparkta.stratio.com/cubes/operators/type",
+                  "type": "string"
+                },
+                "configuration": {
+                  "id": "http://sparkta.stratio.com/cubes/operators/configuration",
+                  "type": "object"
+                }
+              },
+              "required": [
+                "name",
+                "type"
+              ]
+            }
+          }
+        },
+        "required": [
+          "name",
+          "checkpointConfig",
+          "dimensions"
+        ]
       }
     },
     "outputs": {
       "id": "http://sparkta.stratio.com/outputs",
       "type": "array",
       "minItems": 1,
-      "uniqueItems": false,
+      "uniqueItems": true,
       "items": {
-        "id": "auto-generated-schema-56"
-      }
-    },
-    "transformations": {
-      "id": "http://sparkta.stratio.com/parsers",
-      "type": "array",
-      "items": {
-        "id": "auto-generated-schema-257"
+        "id": "http://sparkta.stratio.com/outputs/",
+        "type": "object",
+        "properties": {
+          "name": {
+            "id": "http://sparkta.stratio.com/outputs/name",
+            "type": "string"
+          },
+          "type": {
+            "id": "http://sparkta.stratio.com/outputs/type",
+            "type": "string"
+          },
+          "configuration": {
+            "id": "http://sparkta.stratio.com/outputs/configuration",
+            "type": "object"
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ]
       }
     }
   },
   "required": [
+    "name",
+    "checkpointPath",
     "input",
     "cubes",
     "outputs"

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/PolicyActor.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/PolicyActor.scala
@@ -46,7 +46,7 @@ class PolicyActor(curatorFramework: CuratorFramework, policyStatusActor: ActorRe
     case Update(policy) => update(policy)
     case Delete(id) => delete(id)
     case Find(id) => find(id)
-    case FindByName(name) => findByName(name.toLowerCase())
+    case FindByName(name) => findByName(name.toLowerCase)
     case FindAll() => findAll()
     case FindByFragment(fragmentType, id) => findByFragment(fragmentType, id)
   }

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/helpers/PolicyHelper.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/helpers/PolicyHelper.scala
@@ -87,14 +87,14 @@ object PolicyHelper {
    */
   private def getCurrentInput(mapInputsOutputs: Map[`type`, Seq[PolicyElementModel]],
                               apConfig: AggregationPoliciesModel): PolicyElementModel = {
-    val currentInputs = mapInputsOutputs.filter(x => if(x._1 == FragmentType.input) true else false)
+    val currentInputs = mapInputsOutputs.filter(x => x._1 == FragmentType.input)
 
     if((currentInputs.nonEmpty && currentInputs.get(FragmentType.input).get.size > 1)
       ||(currentInputs.nonEmpty && currentInputs.get(FragmentType.input).get.size == 1 && apConfig.input.isDefined)) {
       throw new IllegalStateException("Only one input is allowed in the policy.")
     }
 
-    if(currentInputs.isEmpty && apConfig.input.isDefined == false) {
+    if(currentInputs.isEmpty && apConfig.input.isEmpty) {
       throw new IllegalStateException("It is mandatory to define one input in the policy.")
     }
 

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/helpers/PolicyHelper.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/helpers/PolicyHelper.scala
@@ -87,14 +87,14 @@ object PolicyHelper {
    */
   private def getCurrentInput(mapInputsOutputs: Map[`type`, Seq[PolicyElementModel]],
                               apConfig: AggregationPoliciesModel): PolicyElementModel = {
-    val currentInputs = mapInputsOutputs.filter(x => x._1 == FragmentType.input)
+    val currentInputs = mapInputsOutputs.filter(x => if(x._1 == FragmentType.input) true else false)
 
     if((currentInputs.nonEmpty && currentInputs.get(FragmentType.input).get.size > 1)
       ||(currentInputs.nonEmpty && currentInputs.get(FragmentType.input).get.size == 1 && apConfig.input.isDefined)) {
       throw new IllegalStateException("Only one input is allowed in the policy.")
     }
 
-    if(currentInputs.isEmpty && apConfig.input.isEmpty) {
+    if(currentInputs.isEmpty && apConfig.input.isDefined == false) {
       throw new IllegalStateException("It is mandatory to define one input in the policy.")
     }
 

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/service/http/PolicyHttpService.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/service/http/PolicyHttpService.scala
@@ -247,7 +247,8 @@ trait PolicyHttpService extends BaseHttpService with SparktaSerializer {
                 case Response(Success(_)) => HttpResponse(StatusCodes.Created)
               }
             }
-          }        }
+          }
+        }
       }
     }
   }
@@ -308,7 +309,7 @@ trait PolicyHttpService extends BaseHttpService with SparktaSerializer {
             validate(isValidAndMessageTuple._1, isValidAndMessageTuple._2) {
               complete {
                 val response = actors.get(AkkaConstant.SparkStreamingContextActor).get ?
-                    new SparkStreamingContextActor.Create(parsedP)
+                  new SparkStreamingContextActor.Create(parsedP)
                 Await.result(response, timeout.duration) match {
                   case Failure(ex) => throw ex
                   case Success(_) => new Result("Creating new context with name " + policy.name)

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/service/http/PolicyHttpService.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/service/http/PolicyHttpService.scala
@@ -210,8 +210,7 @@ trait PolicyHttpService extends BaseHttpService with SparktaSerializer {
     path(HttpConstant.PolicyPath) {
       post {
         entity(as[AggregationPoliciesModel]) { policy =>
-          val parsedP = getPolicyWithFragments(policy)
-          val isValidAndMessageTuple = AggregationPoliciesValidator.validateDto(parsedP)
+          val isValidAndMessageTuple = AggregationPoliciesValidator.validateDto(getPolicyWithFragments(policy))
           validate(isValidAndMessageTuple._1, isValidAndMessageTuple._2) {
             val future = supervisor ? new Create(policy)
             Await.result(future, timeout.duration) match {
@@ -238,8 +237,7 @@ trait PolicyHttpService extends BaseHttpService with SparktaSerializer {
     path(HttpConstant.PolicyPath) {
       put {
         entity(as[AggregationPoliciesModel]) { policy =>
-          val parsedP = getPolicyWithFragments(policy)
-          val isValidAndMessageTuple = AggregationPoliciesValidator.validateDto(parsedP)
+          val isValidAndMessageTuple = AggregationPoliciesValidator.validateDto(getPolicyWithFragments(policy))
           validate(isValidAndMessageTuple._1, isValidAndMessageTuple._2) {
           complete {
             val future = supervisor ? new Update(policy)
@@ -350,12 +348,11 @@ trait PolicyHttpService extends BaseHttpService with SparktaSerializer {
         Await.result(future, timeout.duration) match {
           case ResponsePolicy(Failure(exception)) => throw exception
           case ResponsePolicy(Success(policy)) => {
-            val parsedP = getPolicyWithFragments(policy)
-            val isValidAndMessageTuple = AggregationPoliciesValidator.validateDto(parsedP)
+            val isValidAndMessageTuple = AggregationPoliciesValidator.validateDto(getPolicyWithFragments(policy))
             validate(isValidAndMessageTuple._1, isValidAndMessageTuple._2) {
-              val tempFile = File.createTempFile(s"${parsedP.id.get}-${parsedP.name}-", ".json")
-              respondWithHeader(`Content-Disposition`("attachment", Map("filename" -> s"${parsedP.name}.json"))) {
-                scala.tools.nsc.io.File(tempFile).writeAll(write(parsedP))
+              val tempFile = File.createTempFile(s"${policy.id.get}-${policy.name}-", ".json")
+              respondWithHeader(`Content-Disposition`("attachment", Map("filename" -> s"${policy.name}.json"))) {
+                scala.tools.nsc.io.File(tempFile).writeAll(write(policy))
                 getFromFile(tempFile)
               }
             }

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/service/http/PolicyHttpService.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/service/http/PolicyHttpService.scala
@@ -309,13 +309,9 @@ trait PolicyHttpService extends BaseHttpService with SparktaSerializer {
               complete {
                 val response = actors.get(AkkaConstant.SparkStreamingContextActor).get ?
                     new SparkStreamingContextActor.Create(parsedP)
-                val error = Await.result(response, timeout.duration) match {
-                  case Failure(ex) => Some(ex)
-                  case Success => None
-                }
-                error match {
-                  case Some(ex: Throwable) => throw ex
-                  case None => new Result("Creating new context with name " + policy.name)
+                Await.result(response, timeout.duration) match {
+                  case Failure(ex) => throw ex
+                  case Success(_) => new Result("Creating new context with name " + policy.name)
                 }
               }
             }

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/service/http/PolicyHttpService.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/service/http/PolicyHttpService.scala
@@ -20,7 +20,6 @@ import java.io.File
 import javax.ws.rs.Path
 
 import akka.pattern.ask
-import akka.util.Timeout
 import com.stratio.sparkta.driver.constants.AkkaConstant
 import com.stratio.sparkta.serving.api.actor.PolicyActor._
 import com.stratio.sparkta.serving.api.actor.SparkStreamingContextActor
@@ -35,7 +34,7 @@ import spray.http.{HttpResponse, StatusCodes}
 import spray.httpx.marshalling.ToResponseMarshallable
 import spray.routing._
 
-import scala.concurrent.{Future, Await}
+import scala.concurrent.Await
 import scala.util.{Failure, Success}
 
 @Api(value = HttpConstant.PolicyPath, description = "Operations over policies.")
@@ -45,7 +44,7 @@ trait PolicyHttpService extends BaseHttpService with SparktaSerializer {
 
   override def routes: Route = find ~ findAll ~ findByFragment ~ create ~ update ~ remove ~ run ~ download ~ findByName
 
-  def getPolicyWithFragments(policy: AggregationPoliciesModel) : AggregationPoliciesModel =
+  def getPolicyWithFragments(policy: AggregationPoliciesModel): AggregationPoliciesModel =
     PolicyHelper.parseFragments(PolicyHelper.fillFragments(policy, actors.get(AkkaConstant.FragmentActor).get, timeout))
 
   @Path("/find/{id}")
@@ -212,10 +211,12 @@ trait PolicyHttpService extends BaseHttpService with SparktaSerializer {
         entity(as[AggregationPoliciesModel]) { policy =>
           val isValidAndMessageTuple = AggregationPoliciesValidator.validateDto(getPolicyWithFragments(policy))
           validate(isValidAndMessageTuple._1, isValidAndMessageTuple._2) {
-            val future = supervisor ? new Create(policy)
-            Await.result(future, timeout.duration) match {
-              case ResponsePolicy(Failure(exception)) => throw exception
-              case ResponsePolicy(Success(pol)) => complete(pol)
+            complete {
+              val future = supervisor ? new Create(policy)
+              Await.result(future, timeout.duration) match {
+                case ResponsePolicy(Failure(exception)) => throw exception
+                case ResponsePolicy(Success(pol)) => pol
+              }
             }
           }
         }
@@ -239,15 +240,14 @@ trait PolicyHttpService extends BaseHttpService with SparktaSerializer {
         entity(as[AggregationPoliciesModel]) { policy =>
           val isValidAndMessageTuple = AggregationPoliciesValidator.validateDto(getPolicyWithFragments(policy))
           validate(isValidAndMessageTuple._1, isValidAndMessageTuple._2) {
-          complete {
-            val future = supervisor ? new Update(policy)
-            Await.result(future, timeout.duration) match {
-              case Response(Failure(exception)) => throw exception
-              case Response(Success(_)) => HttpResponse(StatusCodes.Created)
+            complete {
+              val future = supervisor ? new Update(policy)
+              Await.result(future, timeout.duration) match {
+                case Response(Failure(exception)) => throw exception
+                case Response(Success(_)) => HttpResponse(StatusCodes.Created)
+              }
             }
-          }
-          }
-        }
+          }        }
       }
     }
   }
@@ -306,17 +306,17 @@ trait PolicyHttpService extends BaseHttpService with SparktaSerializer {
             val parsedP = getPolicyWithFragments(policy)
             val isValidAndMessageTuple = AggregationPoliciesValidator.validateDto(parsedP)
             validate(isValidAndMessageTuple._1, isValidAndMessageTuple._2) {
-              val a = actors.get(AkkaConstant.SparkStreamingContextActor).get ? new SparkStreamingContextActor.Create (parsedP)
-              val error=  Await.result(a,timeout.duration) match {
-                case Failure(ex)=>Some(ex)
-                case Success(_) => None
-              }
               complete {
-                error match {
-                  case Some(ex:Throwable)=> throw ex
-                  case None =>new Result("Creating new context with name " + policy.name)
+                val response = actors.get(AkkaConstant.SparkStreamingContextActor).get ?
+                    new SparkStreamingContextActor.Create(parsedP)
+                val error = Await.result(response, timeout.duration) match {
+                  case Failure(ex) => Some(ex)
+                  case Success => None
                 }
-
+                error match {
+                  case Some(ex: Throwable) => throw ex
+                  case None => new Result("Creating new context with name " + policy.name)
+                }
               }
             }
           }
@@ -350,10 +350,12 @@ trait PolicyHttpService extends BaseHttpService with SparktaSerializer {
           case ResponsePolicy(Success(policy)) => {
             val isValidAndMessageTuple = AggregationPoliciesValidator.validateDto(getPolicyWithFragments(policy))
             validate(isValidAndMessageTuple._1, isValidAndMessageTuple._2) {
-              val tempFile = File.createTempFile(s"${policy.id.get}-${policy.name}-", ".json")
-              respondWithHeader(`Content-Disposition`("attachment", Map("filename" -> s"${policy.name}.json"))) {
-                scala.tools.nsc.io.File(tempFile).writeAll(write(policy))
-                getFromFile(tempFile)
+              complete {
+                val tempFile = File.createTempFile(s"${policy.id.get}-${policy.name}-", ".json")
+                respondWithHeader(`Content-Disposition`("attachment", Map("filename" -> s"${policy.name}.json"))) {
+                  scala.tools.nsc.io.File(tempFile).writeAll(write(policy))
+                  getFromFile(tempFile)
+                }
               }
             }
           }


### PR DESCRIPTION
#### Description
Added all types and rules for the policy validation in json level.
Now validate in the update process too.
The returned json value has been changed with the fillFragments process.

It close #924 #939 and #834 

#### Test
All passed.

#### Coverage
No changes

#### Scalastyle
No info