### PR TITLE
fix initital configuration scripts

### DIFF
--- a/examples/scripts/loadExampleConfiguration_Cassandra.sh
+++ b/examples/scripts/loadExampleConfiguration_Cassandra.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 
-INPUT=`curl -sX POST -H "Content-Type: application/json" --data @../policies/fragments/WebSocketFragment.json localhost:9090/fragment | jq '.id' | sed -e "s/\"//g"`
+FRAGMENT=$(curl -sX GET -H "Content-Type: application/json" localhost:9090/fragment/input/name/websocket | jq '.id')
+
+if [ "$FRAGMENT" == "null" ]; then
+  INPUT=$(curl -sX POST -H "Content-Type: application/json" --data @../policies/fragments/WebSocketFragment.json localhost:9090/fragment | jq '.id' | sed -e "s/\"//g")
+else
+  INPUT = $(echo "$FRAGMENT" | tr -d '"')
+fi
 echo $INPUT
-OUTPUT=`curl -sX POST -H "Content-Type: application/json" --data @../policies/fragments/CassandraFragment.json localhost:9090/fragment | jq '.id' | sed -e "s/\"//g"`
+
+OUTPUT=$(curl -sX POST -H "Content-Type: application/json" --data @../policies/fragments/CassandraFragment.json localhost:9090/fragment | jq '.id' | sed -e "s/\"//g")
 echo $OUTPUT
+
 cat ../policies/fragments/IWebSocket-OCassandra.json|sed -e "s/_input_id_/$INPUT/g"|sed -e "s/_output_id_/$OUTPUT/g" >temp.json
 
-POL=`curl -sX POST -H "Content-Type: application/json" --data @./temp.json  localhost:9090/policy |jq '.id'| sed -e "s/\"//g"`
-
+POL=$(curl -sX POST -H "Content-Type: application/json" --data @./temp.json  localhost:9090/policy |jq '.id'| sed -e "s/\"//g")
 echo $POL

--- a/examples/scripts/loadExampleConfiguration_Elasticsearch.sh
+++ b/examples/scripts/loadExampleConfiguration_Elasticsearch.sh
@@ -1,12 +1,17 @@
-#!/usr/bin/env bash
 
-INPUT=`curl -sX POST -H "Content-Type: application/json" --data @../policies/fragments/WebSocketFragment.json localhost:9090/fragment | jq '.id' | sed -e "s/\"//g"`
+FRAGMENT=$(curl -sX GET -H "Content-Type: application/json" localhost:9090/fragment/input/name/websocket | jq '.id')
+
+if [ "$FRAGMENT" == "null" ]; then
+  INPUT=$(curl -sX POST -H "Content-Type: application/json" --data @../policies/fragments/WebSocketFragment.json localhost:9090/fragment | jq '.id' | sed -e "s/\"//g")
+else
+  INPUT = $(echo "$FRAGMENT" | tr -d '"')
+fi
 echo $INPUT
-OUTPUT=`curl -sX POST -H "Content-Type: application/json" --data @../policies/fragments/ElasticSearchFragment.json localhost:9090/fragment | jq '.id' | sed -e "s/\"//g"`
+
+OUTPUT=$(curl -sX POST -H "Content-Type: application/json" --data @../policies/fragments/ElasticSearchFragment.json localhost:9090/fragment | jq '.id' | sed -e "s/\"//g")
 echo $OUTPUT
+
 cat ../policies/fragments/IWebSocket-OElasticsearch.json|sed -e "s/_input_id_/$INPUT/g"|sed -e "s/_output_id_/$OUTPUT/g" >temp.json
 
-POL=`curl -X POST -H "Content-Type: application/json" --data @./temp.json  localhost:9090/policy`
-
-
+POL=$(curl -X POST -H "Content-Type: application/json" --data @./temp.json  localhost:9090/policy)
 echo $POL

--- a/examples/scripts/loadExampleConfiguration_Mongo.sh
+++ b/examples/scripts/loadExampleConfiguration_Mongo.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 
-INPUT=`curl -sX POST -H "Content-Type: application/json" --data @../policies/fragments/WebSocketFragment.json localhost:9090/fragment | jq '.id' | sed -e "s/\"//g"`
+FRAGMENT=$(curl -sX GET -H "Content-Type: application/json" localhost:9090/fragment/input/name/websocket | jq '.id')
+
+if [ "$FRAGMENT" == "null" ]; then
+  INPUT=$(curl -sX POST -H "Content-Type: application/json" --data @../policies/fragments/WebSocketFragment.json localhost:9090/fragment | jq '.id' | sed -e "s/\"//g")
+else
+  INPUT = $(echo "$FRAGMENT" | tr -d '"')
+fi
 echo $INPUT
-OUTPUT=`curl -sX POST -H "Content-Type: application/json" --data @../policies/fragments/MongoFragment.json localhost:9090/fragment | jq '.id' | sed -e "s/\"//g"`
+
+OUTPUT=$(curl -sX POST -H "Content-Type: application/json" --data @../policies/fragments/MongoFragment.json localhost:9090/fragment | jq '.id' | sed -e "s/\"//g")
 echo $OUTPUT
+
 cat ../policies/fragments/IWebSocket-OMongo.json|sed -e "s/_input_id_/$INPUT/g"|sed -e "s/_output_id_/$OUTPUT/g" >temp.json
 
-curl -X POST -H "Content-Type: application/json" --data @./temp.json  localhost:9090/policy
-
-
+POL=$(curl -X POST -H "Content-Type: application/json" --data @./temp.json  localhost:9090/policy)
 echo $POL


### PR DESCRIPTION
Currently, manager is running all scripts (provided all persistances are installed) which creates issues with the input fragment creation. Each script tries to create the input fragment again, creating havoc when trying to create the policy.

A new check has been added to verify whether the fragment already exists or not. If it doesn't exist, we create it, and if it exists, we use the existing id.