### PR TITLE
DateTimefield type accept long types

### DIFF
--- a/plugins/field-dateTime/src/main/scala/com/stratio/sparkta/plugin/field/datetime/DateTimeField.scala
+++ b/plugins/field-dateTime/src/main/scala/com/stratio/sparkta/plugin/field/datetime/DateTimeField.scala
@@ -39,19 +39,10 @@ case class DateTimeField(props: Map[String, JSerializable])
     if (!props.contains(GranularityPropertyName)) Map(GranularityPropertyName -> DefaultGranularity) else Map()
   }
 
-  final val PrecisionMap = Map(
-    SecondName -> getPrecision(SecondName, getTypeOperation(SecondName)),
-    MinuteName -> getPrecision(MinuteName, getTypeOperation(MinuteName)),
-    HourName -> getPrecision(HourName, getTypeOperation(HourName)),
-    DayName -> getPrecision(DayName, getTypeOperation(DayName)),
-    MonthName -> getPrecision(MonthName, getTypeOperation(MonthName)),
-    YearName -> getPrecision(YearName, getTypeOperation(YearName)),
-    s15Name -> getPrecision(s15Name, getTypeOperation(s15Name)),
-    s10Name -> getPrecision(s10Name, getTypeOperation(s10Name)),
-    s5Name -> getPrecision(s5Name, getTypeOperation(s5Name))
-  )
-  
-  override def precision(keyName: String): Precision = PrecisionMap.getOrElse(keyName, timestamp)
+  override def precision(keyName: String): Precision = {
+    if (DateTimeField.Precisions.contains(keyName)) getPrecision(keyName, getTypeOperation(keyName))
+    else timestamp
+  }
 
   @throws(classOf[ClassCastException])
   override def precisionValue(keyName: String, value: JSerializable): (Precision, JSerializable) =
@@ -81,6 +72,7 @@ object DateTimeField {
   final val s15Name = "s15"
   final val s10Name = "s10"
   final val s5Name = "s5"
+  final val Precisions = Seq(SecondName, MinuteName, HourName, DayName, MonthName, YearName, s15Name, s10Name, s5Name)
   final val timestamp = DimensionType.getTimestamp(Some(TypeOp.Timestamp), TypeOp.Timestamp)
 
   def getPrecision(value: Date, precision: Precision, properties: Map[String, JSerializable]): JSerializable = {

--- a/plugins/field-dateTime/src/test/scala/com/stratio/sparkta/plugin/field/datetime/test/DateTimeFieldSpec.scala
+++ b/plugins/field-dateTime/src/test/scala/com/stratio/sparkta/plugin/field/datetime/test/DateTimeFieldSpec.scala
@@ -20,10 +20,10 @@ import java.io.{Serializable => JSerializable}
 import java.util.Date
 
 import com.stratio.sparkta.plugin.field.datetime.DateTimeField
+import com.stratio.sparkta.sdk.TypeOp
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{Matchers, WordSpecLike}
-import com.stratio.sparkta.sdk.TypeOp
 
 @RunWith(classOf[JUnitRunner])
 class DateTimeFieldSpec extends WordSpecLike with Matchers {

--- a/plugins/field-dateTime/src/test/scala/com/stratio/sparkta/plugin/field/datetime/test/DateTimeFieldSpec.scala
+++ b/plugins/field-dateTime/src/test/scala/com/stratio/sparkta/plugin/field/datetime/test/DateTimeFieldSpec.scala
@@ -34,6 +34,12 @@ class DateTimeFieldSpec extends WordSpecLike with Matchers {
   "A DateTimeDimension" should {
     "In default implementation, get 6 dimensions for a specific time" in {
       val newDate = new Date()
+      val precision5s =
+        dateTimeDimension.precisionValue(DateTimeField.s5Name, newDate.asInstanceOf[JSerializable])
+      val precision10s =
+        dateTimeDimension.precisionValue(DateTimeField.s10Name, newDate.asInstanceOf[JSerializable])
+      val precision15s =
+        dateTimeDimension.precisionValue(DateTimeField.s15Name, newDate.asInstanceOf[JSerializable])
       val precisionSecond =
         dateTimeDimension.precisionValue(DateTimeField.SecondName, newDate.asInstanceOf[JSerializable])
       val precisionMinute =
@@ -47,6 +53,9 @@ class DateTimeFieldSpec extends WordSpecLike with Matchers {
       val precisionYear =
         dateTimeDimension.precisionValue(DateTimeField.YearName, newDate.asInstanceOf[JSerializable])
 
+      precision5s._1.id should be(DateTimeField.s5Name)
+      precision10s._1.id should be(DateTimeField.s10Name)
+      precision15s._1.id should be(DateTimeField.s15Name)
       precisionSecond._1.id should be(DateTimeField.SecondName)
       precisionMinute._1.id should be(DateTimeField.MinuteName)
       precisionHour._1.id should be(DateTimeField.HourName)
@@ -56,12 +65,15 @@ class DateTimeFieldSpec extends WordSpecLike with Matchers {
     }
 
     "Each precision dimension have their output type, second must be long, minute must be date, others datetime" in {
+      dateTimeDimension.precision(DateTimeField.s5Name).typeOp should be(TypeOp.DateTime)
+      dateTimeDimension.precision(DateTimeField.s10Name).typeOp should be(TypeOp.DateTime)
+      dateTimeDimension.precision(DateTimeField.s15Name).typeOp should be(TypeOp.DateTime)
       dateTimeDimension.precision(DateTimeField.SecondName).typeOp should be(TypeOp.Long)
       dateTimeDimension.precision(DateTimeField.MinuteName).typeOp should be(TypeOp.Date)
       dateTimeDimension.precision(DateTimeField.DayName).typeOp should be(TypeOp.DateTime)
       dateTimeDimension.precision(DateTimeField.MonthName).typeOp should be(TypeOp.DateTime)
       dateTimeDimension.precision(DateTimeField.YearName).typeOp should be(TypeOp.DateTime)
-      dateTimeDimension.precision(DateTimeField.timestamp.id).typeOp should be(TypeOp.DateTime)
+      dateTimeDimension.precision(DateTimeField.timestamp.id).typeOp should be(TypeOp.Timestamp)
     }
   }
 }


### PR DESCRIPTION
#### Description
SPARKTA-1201. Now we can accept long types because we can convert to the correct Date type with the typeConversions trait.

#### Reviewer
@sgomezg  @anistal 

#### Test
Added more cases in the test.

#### Scalastyle
Removed scala style problem.