### PR TITLE
Policies auto-versioned in Zookeeper for Outputs tables names

### DIFF
--- a/doc/src/site/sphinx/outputs.rst
+++ b/doc/src/site/sphinx/outputs.rst
@@ -197,6 +197,11 @@ The Cassandra output uses the generic implementation with DataFrames.
 |                       | feature is for the Stratio's Cassandra Lucene Index      |          |                       |
 +-----------------------+----------------------------------------------------------+----------+-----------------------+
 
+In Cassandra each cube define one table, but when you modify the policy that involve this cube, Sparkta create a new
+table with the next version. The name of all tables are "dimensions_v1" when modify the policy the new table in
+Cassandra are "dimensions_v2".
+
+
 .. _elasticsearch-label:
 
 ElasticSearch Configuration

--- a/driver/src/main/scala/com/stratio/sparkta/driver/SparktaJob.scala
+++ b/driver/src/main/scala/com/stratio/sparkta/driver/SparktaJob.scala
@@ -160,10 +160,11 @@ object SparktaJob extends SLF4JLogging {
     apConfig.outputs.map(o => (o.name, refUtils.tryToInstantiate[Output](o.`type` + Output.ClassSuffix, (c) =>
       c.getDeclaredConstructor(
         classOf[String],
+        classOf[Option[Int]],
         classOf[Map[String, Serializable]],
         classOf[Option[Map[String, (WriteOp, TypeOp)]]],
         classOf[Option[Seq[TableSchema]]])
-        .newInstance(o.name, o.configuration, bcOperatorsKeyOperation, bcCubeOperatorSchema)
+        .newInstance(o.name, apConfig.version, o.configuration, bcOperatorsKeyOperation, bcCubeOperatorSchema)
         .asInstanceOf[Output])))
 
   def cubes(apConfig: AggregationPoliciesModel, refUtils: ReflectionUtils): Seq[Cube] =

--- a/driver/src/test/scala/com/stratio/sparkta/driver/test/models/AggregationPoliciesSpec.scala
+++ b/driver/src/test/scala/com/stratio/sparkta/driver/test/models/AggregationPoliciesSpec.scala
@@ -54,6 +54,7 @@ with Matchers {
 
       val apd = new AggregationPoliciesModel(
         None,
+        None,
         storageLevel,
         "policy-name",
         "policy description",
@@ -72,6 +73,7 @@ with Matchers {
 
       val sparkStreamingWindowBad = 20000
       val apdBad = new AggregationPoliciesModel(
+        None,
         None,
         storageLevel,
         "policy-name",

--- a/plugins/output-cassandra/src/main/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraOutput.scala
+++ b/plugins/output-cassandra/src/main/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraOutput.scala
@@ -68,7 +68,6 @@ class CassandraOutput(keyName: String,
 
   override def setup: Unit = {
 
-
     val connector = getCassandraConnector()
 
     val keyspaceCreated = createKeypace(connector)

--- a/plugins/output-cassandra/src/test/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraDaoSpec.scala
+++ b/plugins/output-cassandra/src/test/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraDaoSpec.scala
@@ -33,6 +33,22 @@ class CassandraDaoSpec extends FlatSpec with Matchers with MockitoSugar with Cas
     StructField("dim1", StringType, false))), "minute"))
   val structField = StructField("name", StringType, false)
   val schema: StructType = StructType(Array(structField))
+  val tableVersion = Some(1)
+
+  "getTableName" should "return the name of the table" in {
+
+    val table = getTableName("table_name")
+
+    table should be("table_name_v1")
+  }
+
+  "getTableName" should "return the first 48 chars of the name of the table" in {
+
+    val table = getTableName("table_name_is_so_loooooooooooooooooooooooooooooooooooooooooooooong")
+
+    table should be("table_name_is_so_looooooooooooooooooooooooooo_v1")
+  }
+
 
   "createIndex" should "return true" in {
 

--- a/plugins/output-cassandra/src/test/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraOutputSpec.scala
+++ b/plugins/output-cassandra/src/test/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraOutputSpec.scala
@@ -33,20 +33,6 @@ class CassandraOutputSpec extends FlatSpec with Matchers with MockitoSugar with 
   val s = "sum"
   val operation = Some(Map(s ->(WriteOp.Inc, TypeOp.Int)))
   val properties = Map(("connectionHost", "127.0.0.1"), ("connectionPort", "9042"))
-  "getTableName" should "return the name of the table" in {
-
-    val table = new CassandraOutput("key", Some(1), properties, operation, None).getTableName("table_name")
-
-    table should be("table_name_V1")
-  }
-
-  "getTableName" should "return the first 48 chars of the name of the table" in {
-
-    val table = new CassandraOutput("key", Some(1), properties, operation, None).
-      getTableName("table_name_is_so_loooooooooooooooooooooooooooooooooooooooooooooong")
-
-    table should be("table_name_is_so_looooooooooooooooooooooooooo_V1")
-  }
 
   "getSparkConfiguration" should "return a Seq with the configuration" in {
     val configuration = Map(("connectionHost", "127.0.0.1"), ("connectionPort", "9042"))

--- a/plugins/output-cassandra/src/test/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraOutputSpec.scala
+++ b/plugins/output-cassandra/src/test/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraOutputSpec.scala
@@ -35,17 +35,17 @@ class CassandraOutputSpec extends FlatSpec with Matchers with MockitoSugar with 
   val properties = Map(("connectionHost", "127.0.0.1"), ("connectionPort", "9042"))
   "getTableName" should "return the name of the table" in {
 
-    val table = new CassandraOutput("key", properties, operation, None).getTableName("table_name")
+    val table = new CassandraOutput("key", Some(1), properties, operation, None).getTableName("table_name")
 
-    table should be("table_name")
+    table should be("table_name_V1")
   }
 
   "getTableName" should "return the first 48 chars of the name of the table" in {
 
-    val table = new CassandraOutput("key", properties, operation, None).
+    val table = new CassandraOutput("key", Some(1), properties, operation, None).
       getTableName("table_name_is_so_loooooooooooooooooooooooooooooooooooooooooooooong")
 
-    table should be("table_name_is_so_loooooooooooooooooooooooooooooo")
+    table should be("table_name_is_so_looooooooooooooooooooooooooo_V1")
   }
 
   "getSparkConfiguration" should "return a Seq with the configuration" in {
@@ -60,7 +60,7 @@ class CassandraOutputSpec extends FlatSpec with Matchers with MockitoSugar with 
     val tableSchema = Seq(TableSchema("outputName", "dim1", StructType(Array(
       StructField("dim1", StringType, false))), "minute"))
 
-    val out =  spy(new CassandraOutput("key", properties, operation, Option(tableSchema)))
+    val out =  spy(new CassandraOutput("key", None, properties, operation, Option(tableSchema)))
     val df: DataFrame = mock[DataFrame]
 
     doNothing().when(out).write(df,"tablename")
@@ -74,7 +74,7 @@ class CassandraOutputSpec extends FlatSpec with Matchers with MockitoSugar with 
 
     val cassandraConnector: CassandraConnector = mock[CassandraConnector]
 
-    val out =  new CassandraOutput("key", properties, operation, Option(tableSchema)) {
+    val out =  new CassandraOutput("key", Some(1), properties, operation, Option(tableSchema)) {
       override val textIndexFields = Option(Array("test"))
       override def getCassandraConnector(): CassandraConnector = {
         cassandraConnector

--- a/plugins/output-csv/src/main/scala/com/stratio/sparkta/plugin/output/csv/CsvOutput.scala
+++ b/plugins/output-csv/src/main/scala/com/stratio/sparkta/plugin/output/csv/CsvOutput.scala
@@ -35,10 +35,11 @@ import scala.util.Try
  * @param bcSchema
  */
 class CsvOutput(keyName: String,
+                version: Option[Int],
                 properties: Map[String, JSerializable],
                 operationTypes: Option[Map[String, (WriteOp, TypeOp)]],
                 bcSchema: Option[Seq[TableSchema]])
-  extends Output(keyName, properties, operationTypes, bcSchema) with Logging {
+  extends Output(keyName, version, properties, operationTypes, bcSchema) with Logging {
 
   val path = properties.getString("path", None)
 

--- a/plugins/output-csv/src/test/scala/com/stratio/sparkta/plugin/output/csv/CsvOutputSpec.scala
+++ b/plugins/output-csv/src/test/scala/com/stratio/sparkta/plugin/output/csv/CsvOutputSpec.scala
@@ -31,7 +31,7 @@ import org.scalatest.{FlatSpec, Matchers}
 class CsvOutputSpec extends FlatSpec with Matchers with MockitoSugar {
   "CsvOutput" should "upsert a file" in {
     val opTypes = Some(Map("sum" ->(WriteOp.Inc, TypeOp.Int)))
-    val out = spy(new CsvOutput("keyName", Map("path" -> "path"), opTypes, None))
+    val out = spy(new CsvOutput("keyName", None, Map("path" -> "path"), opTypes, None))
     val dataframe = mock[DataFrame]
     implicit val savemock = mock[CsvSchemaRDD]
     doNothing().when(out).saveAction(any[String], meq(dataframe))

--- a/plugins/output-elasticsearch/src/main/scala/com/stratio/sparkta/plugin/output/elasticsearch/ElasticSearchOutput.scala
+++ b/plugins/output-elasticsearch/src/main/scala/com/stratio/sparkta/plugin/output/elasticsearch/ElasticSearchOutput.scala
@@ -41,10 +41,11 @@ import org.elasticsearch.spark.sql._
  *
  */
 class ElasticSearchOutput(keyName: String,
+                          version: Option[Int],
                           properties: Map[String, JSerializable],
                           operationTypes: Option[Map[String, (WriteOp, TypeOp)]],
                           bcSchema: Option[Seq[TableSchema]])
-  extends Output(keyName, properties, operationTypes, bcSchema) with ElasticSearchDAO {
+  extends Output(keyName, version, properties, operationTypes, bcSchema) with ElasticSearchDAO {
 
   override val idField = properties.getString("idField", None)
 

--- a/plugins/output-elasticsearch/src/test/scala/com/stratio/sparkta/plugin/output/elasticsearch/ElasticSearchOutputSpec.scala
+++ b/plugins/output-elasticsearch/src/test/scala/com/stratio/sparkta/plugin/output/elasticsearch/ElasticSearchOutputSpec.scala
@@ -36,7 +36,7 @@ class ElasticSearchOutputSpec extends FlatSpec with ShouldMatchers {
     final val localPort = 9200
     final val remotePort = 9300
     val output = getInstance()
-    val outputMultipleNodes = new ElasticSearchOutput("ES-out",
+    val outputMultipleNodes = new ElasticSearchOutput("ES-out", None,
       Map("nodes" ->
         new JsoneyString(
           s"""[{"node":"host-a","tcpPort":"$remotePort","httpPort":"$localPort"},{"node":"host-b",
@@ -45,7 +45,7 @@ class ElasticSearchOutputSpec extends FlatSpec with ShouldMatchers {
 
     def getInstance(host: String = "localhost", httpPort: Int = localPort, tcpPort : Int = remotePort)
     : ElasticSearchOutput =
-      new ElasticSearchOutput("ES-out",
+      new ElasticSearchOutput("ES-out", None,
         Map("nodes" -> new JsoneyString( s"""[{"node":"$host","httpPort":"$httpPort","tcpPort":"$tcpPort"}]"""),
           "dateType" -> "timestamp",
         "clusterName" -> "elasticsearch"), None, None)
@@ -72,7 +72,7 @@ class ElasticSearchOutputSpec extends FlatSpec with ShouldMatchers {
       """[{"node":"localhost","httpPort":"9200","tcpPort":"9300"}]""".stripMargin),
       "dateType" -> "timestamp",
       "clusterName" -> "elasticsearch")
-    override val output = new ElasticSearchOutput("ES-out", properties, None, bcSchema = Some(Seq(tableSchema)))
+    override val output = new ElasticSearchOutput("ES-out", None, properties, None, bcSchema = Some(Seq(tableSchema)))
   }
 
   trait SchemaValues extends BaseValues {

--- a/plugins/output-mongodb/src/main/scala/com/stratio/sparkta/plugin/output/mongodb/MongoDbOutput.scala
+++ b/plugins/output-mongodb/src/main/scala/com/stratio/sparkta/plugin/output/mongodb/MongoDbOutput.scala
@@ -31,10 +31,11 @@ import org.apache.spark.streaming.dstream.DStream
 import scala.util.Try
 
 class MongoDbOutput(keyName: String,
+                    version: Option[Int],
                     properties: Map[String, JSerializable],
                     operationTypes: Option[Map[String, (WriteOp, TypeOp)]],
                     bcSchema: Option[Seq[TableSchema]])
-  extends Output(keyName, properties, operationTypes, bcSchema) with MongoDbDAO {
+  extends Output(keyName, version, properties, operationTypes, bcSchema) with MongoDbDAO {
 
   RegisterJodaTimeConversionHelpers()
 

--- a/plugins/output-parquet/src/main/scala/com/stratio/sparkta/plugin/output/parquet/ParquetOutput.scala
+++ b/plugins/output-parquet/src/main/scala/com/stratio/sparkta/plugin/output/parquet/ParquetOutput.scala
@@ -36,10 +36,11 @@ import com.stratio.sparkta.sdk._
  * @param bcSchema
  */
 class ParquetOutput(keyName: String,
+                    version: Option[Int],
                     properties: Map[String, JSerializable],
                     operationTypes: Option[Map[String, (WriteOp, TypeOp)]],
                     bcSchema: Option[Seq[TableSchema]])
-  extends Output(keyName, properties, operationTypes, bcSchema) with Logging {
+  extends Output(keyName, version, properties, operationTypes, bcSchema) with Logging {
 
   override def upsert(dataFrame: DataFrame, tableName: String, timeDimension: String): Unit = {
     val path = properties.getString("path", None)

--- a/plugins/output-parquet/src/test/scala/com/stratio/sparkta/plugin/output/parquet/ParquetOutputIT.scala
+++ b/plugins/output-parquet/src/test/scala/com/stratio/sparkta/plugin/output/parquet/ParquetOutputIT.scala
@@ -57,12 +57,12 @@ class ParquetOutputIT extends FlatSpec with ShouldMatchers with BeforeAndAfterAl
   trait WithEventData extends CommonValues {
 
     val properties = Map("path" -> tmpPath)
-    val output = new ParquetOutput("parquet-test", properties, None, None)
+    val output = new ParquetOutput("parquet-test", None, properties, None, None)
   }
 
   trait WithWrongOutput extends CommonValues {
 
-    val output = new ParquetOutput("parquet-test", Map(), None, None)
+    val output = new ParquetOutput("parquet-test", None, Map(), None, None)
   }
 
   trait WithDatePattern extends CommonValues {
@@ -70,7 +70,7 @@ class ParquetOutputIT extends FlatSpec with ShouldMatchers with BeforeAndAfterAl
     val datePattern = "yyyy/MM/dd"
     val properties = Map("path" -> tmpPath, "datePattern" -> datePattern)
     val granularity = "minute"
-    val output = new ParquetOutput("parquet-test", properties, None, None)
+    val output = new ParquetOutput("parquet-test", None, properties, None, None)
     val dt = DateTime.now
     val expectedPath = "/" + DateTimeFormat.forPattern(datePattern).print(dt) + "/" + dt.withMillisOfSecond(0)
       .withSecondOfMinute(0).getMillis
@@ -80,7 +80,7 @@ class ParquetOutputIT extends FlatSpec with ShouldMatchers with BeforeAndAfterAl
 
     val datePattern = "yyyy/MM/dd"
     val properties = Map("path" -> tmpPath, "datePattern" -> datePattern)
-    val output = new ParquetOutput("parquet-test", properties, None, None)
+    val output = new ParquetOutput("parquet-test", None, properties, None, None)
     val expectedPath = "/0"
   }
 

--- a/plugins/output-print/src/main/scala/com/stratio/sparkta/plugin/output/print/PrintOutput.scala
+++ b/plugins/output-print/src/main/scala/com/stratio/sparkta/plugin/output/print/PrintOutput.scala
@@ -34,14 +34,16 @@ import com.stratio.sparkta.sdk._
  * @param bcSchema
  */
 class PrintOutput(keyName: String,
+                  version: Option[Int],
                   properties: Map[String, JSerializable],
                   operationTypes: Option[Map[String, (WriteOp, TypeOp)]],
                   bcSchema: Option[Seq[TableSchema]])
-  extends Output(keyName, properties, operationTypes, bcSchema) with Logging {
+  extends Output(keyName, version, properties, operationTypes, bcSchema) with Logging {
 
   override def upsert(dataFrame: DataFrame, tableName: String, timeDimension: String): Unit = {
     if (log.isDebugEnabled) {
       log.debug(s"> Table name       : $tableName")
+      log.debug(s"> Version policy   : $version")
       log.debug(s"> Data frame count : " + dataFrame.count())
       log.debug(s"> DataFrame schema")
       dataFrame.printSchema()

--- a/plugins/output-redis/src/main/scala/com/stratio/sparkta/plugin/output/redis/RedisOutput.scala
+++ b/plugins/output-redis/src/main/scala/com/stratio/sparkta/plugin/output/redis/RedisOutput.scala
@@ -32,10 +32,11 @@ import org.apache.spark.streaming.dstream.DStream
  * @author anistal
  */
 class RedisOutput(keyName: String,
+                  version: Option[Int],
                   properties: Map[String, Serializable],
                   operationTypes: Option[Map[String, (WriteOp, TypeOp)]],
                   bcSchema: Option[Seq[TableSchema]])
-  extends Output(keyName, properties, operationTypes, bcSchema)
+  extends Output(keyName, version, properties, operationTypes, bcSchema)
   with AbstractRedisDAO with Serializable {
 
   override val hostname = properties.getString("hostname", DefaultRedisHostname)

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/Output.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/Output.scala
@@ -30,6 +30,7 @@ import com.stratio.sparkta.sdk.ValidatingPropertyMap.map2ValidatingPropertyMap
 import com.stratio.sparkta.sdk.WriteOp.WriteOp
 
 abstract class Output(keyName: String,
+                      version: Option[Int],
                       properties: Map[String, JSerializable],
                       operationTypes: Option[Map[String, (WriteOp, TypeOp)]],
                       bcSchema: Option[Seq[TableSchema]])

--- a/sdk/src/test/scala/com/stratio/sparkta/sdk/OutputSpec.scala
+++ b/sdk/src/test/scala/com/stratio/sparkta/sdk/OutputSpec.scala
@@ -55,16 +55,19 @@ class OutputSpec extends WordSpec with Matchers {
     val outputName = "outputName"
 
     val output = new OutputMock(outputName,
+      None,
       Map(),
       Some(Map("op1" ->(WriteOp.Set, TypeOp.Long))),
       Some(Seq(tableSchema)))
 
     val outputOperation = new OutputMock(outputName,
+      None,
       Map(),
       Some(Map("op1" ->(WriteOp.Inc, TypeOp.Long))),
       Some(Seq(tableSchema)))
 
     val outputProps = new OutputMock(outputName,
+      None,
       Map(
         "fixedDimensions" -> "dim2",
         "fixedAggregation" -> "op2:1",

--- a/sdk/src/test/scala/com/stratio/sparkta/sdk/test/OutputMock.scala
+++ b/sdk/src/test/scala/com/stratio/sparkta/sdk/test/OutputMock.scala
@@ -23,9 +23,11 @@ import com.stratio.sparkta.sdk.WriteOp._
 import com.stratio.sparkta.sdk.{Output, TableSchema, WriteOp}
 
 class OutputMock(keyName: String,
+                 version: Option[Int],
                  properties: Map[String, JSerializable],
                  operationTypes: Option[Map[String, (WriteOp, TypeOp)]],
-                 bcSchema: Option[Seq[TableSchema]]) extends Output(keyName, properties, operationTypes, bcSchema) {
+                 bcSchema: Option[Seq[TableSchema]])
+  extends Output(keyName, version, properties, operationTypes, bcSchema) {
 
   override val supportedWriteOps = Seq(WriteOp.Set)
 }

--- a/serving-api/src/test/scala/com/stratio/sparkta/serving/api/service/http/HttpServiceBaseSpec.scala
+++ b/serving-api/src/test/scala/com/stratio/sparkta/serving/api/service/http/HttpServiceBaseSpec.scala
@@ -82,6 +82,7 @@ with SparktaSerializer {
     val outputs = Seq(PolicyElementModel("mongo", "MongoDb", Map()))
     val input = Some(PolicyElementModel("kafka", "Kafka", Map()))
     val policy = AggregationPoliciesModel(id = Option("id"),
+      version = None,
       storageLevel = AggregationPoliciesModel.storageDefaultValue,
       name = "testpolicy",
       description = "whatever",

--- a/serving-core/src/main/scala/com/stratio/sparkta/serving/core/models/AggregationPoliciesModel.scala
+++ b/serving-core/src/main/scala/com/stratio/sparkta/serving/core/models/AggregationPoliciesModel.scala
@@ -28,6 +28,7 @@ import org.json4s.jackson.JsonMethods._
 import scala.collection.JavaConversions._
 
 case class AggregationPoliciesModel(id: Option[String] = None,
+                                    version: Option[Int] = None,
                                     storageLevel: Option[String] = AggregationPoliciesModel.storageDefaultValue,
                                     name: String,
                                     description: String = "default description",

--- a/serving-core/src/test/scala/com/stratio/sparkta/serving/core/helpers/PolicyHelperSpec.scala
+++ b/serving-core/src/test/scala/com/stratio/sparkta/serving/core/helpers/PolicyHelperSpec.scala
@@ -36,6 +36,7 @@ class PolicyHelperSpec extends FeatureSpec with GivenWhenThen with Matchers {
 
       val ap = new AggregationPoliciesModel(
         None,
+        None,
         storageLevel,
         "policy-test",
         "policy description",
@@ -83,6 +84,7 @@ class PolicyHelperSpec extends FeatureSpec with GivenWhenThen with Matchers {
 
     val ap = new AggregationPoliciesModel(
       None,
+      None,
       storageLevel,
       "policy-test",
       "policy description",
@@ -123,6 +125,7 @@ class PolicyHelperSpec extends FeatureSpec with GivenWhenThen with Matchers {
     val checkpointDir = "checkpoint"
 
     val ap = new AggregationPoliciesModel(
+      None,
       None,
       storageLevel,
       "policy-test",

--- a/serving-core/src/test/scala/com/stratio/sparkta/serving/core/models/test/AggregationPolicySpec.scala
+++ b/serving-core/src/test/scala/com/stratio/sparkta/serving/core/models/test/AggregationPolicySpec.scala
@@ -65,6 +65,7 @@ class AggregationPolicySpec extends WordSpec with Matchers {
   val outputs = Seq(PolicyElementModel("mongo", "MongoDb", Map()))
   val input = Some(PolicyElementModel("kafka", "Kafka", Map()))
   val policy = AggregationPoliciesModel(id = None,
+    version = None,
     storageLevel = AggregationPoliciesModel.storageDefaultValue,
     name = "testpolicy",
     description = "whatever",

--- a/test-at/src/test/scala/com/stratio/sparkta/testat/outputs/ISocketOCassandraOperatorsIT.scala
+++ b/test-at/src/test/scala/com/stratio/sparkta/testat/outputs/ISocketOCassandraOperatorsIT.scala
@@ -57,7 +57,7 @@ class ISocketOCassandraOperatorsIT extends SparktaATSuite {
       val cluster = Cluster.builder().addContactPoints(Localhost).withPort(CassandraPort).build()
       val session: Session = cluster.connect("sparkta")
 
-      val resultProductA: ResultSet = session.execute("select * from product_minute where product = 'producta'")
+      val resultProductA: ResultSet = session.execute("select * from product_minute_V1 where product = 'producta'")
       val rowProductA = resultProductA.iterator().next()
 
       rowProductA.getDouble("avg_price") should be(639.0d)
@@ -76,7 +76,7 @@ class ISocketOCassandraOperatorsIT extends SparktaATSuite {
       counts should be(Map("hola" -> new lang.Long(16), "holo" -> new lang.Long(8)))
       rowProductA.getInt("totalentity_text") should be(24)
 
-      val resultProductB: ResultSet = session.execute("select * from product_minute where product = 'productb'")
+      val resultProductB: ResultSet = session.execute("select * from product_minute_V1 where product = 'productb'")
       val rowProductB = resultProductB.iterator().next()
 
       rowProductB.getDouble("avg_price") should be(758.25d)

--- a/test-at/src/test/scala/com/stratio/sparkta/testat/outputs/ISocketOCassandraOperatorsIT.scala
+++ b/test-at/src/test/scala/com/stratio/sparkta/testat/outputs/ISocketOCassandraOperatorsIT.scala
@@ -57,7 +57,7 @@ class ISocketOCassandraOperatorsIT extends SparktaATSuite {
       val cluster = Cluster.builder().addContactPoints(Localhost).withPort(CassandraPort).build()
       val session: Session = cluster.connect("sparkta")
 
-      val resultProductA: ResultSet = session.execute("select * from product_minute_V1 where product = 'producta'")
+      val resultProductA: ResultSet = session.execute("select * from product_minute_v1 where product = 'producta'")
       val rowProductA = resultProductA.iterator().next()
 
       rowProductA.getDouble("avg_price") should be(639.0d)
@@ -76,7 +76,7 @@ class ISocketOCassandraOperatorsIT extends SparktaATSuite {
       counts should be(Map("hola" -> new lang.Long(16), "holo" -> new lang.Long(8)))
       rowProductA.getInt("totalentity_text") should be(24)
 
-      val resultProductB: ResultSet = session.execute("select * from product_minute_V1 where product = 'productb'")
+      val resultProductB: ResultSet = session.execute("select * from product_minute_v1 where product = 'productb'")
       val rowProductB = resultProductB.iterator().next()
 
       rowProductB.getDouble("avg_price") should be(758.25d)

--- a/web/src/data-templates/output.json
+++ b/web/src/data-templates/output.json
@@ -30,16 +30,6 @@
         "qa": "fragment-details-cassandra-connectionPort"
       },
       {
-        "propertyId": "cluster",
-        "propertyName": "_CLUSTER_",
-        "propertyType": "text",
-        "regexp": "",
-        "default": "Sparkta",
-        "required": true,
-        "tooltip": "Cluster name.",
-        "qa": "fragment-details-cassandra-cluster"
-      },
-      {
         "propertyId": "keyspace",
         "propertyName": "_KEYSPACE_",
         "propertyType": "text",
@@ -48,6 +38,16 @@
         "required": true,
         "tooltip": "Keyspace name.",
         "qa": "fragment-details-cassandra-keyspace"
+      },
+      {
+        "propertyId": "cluster",
+        "propertyName": "_CLUSTER_",
+        "propertyType": "text",
+        "regexp": "",
+        "default": "Sparkta",
+        "required": true,
+        "tooltip": "Cluster name.",
+        "qa": "fragment-details-cassandra-cluster"
       },
       {
         "propertyId": "keyspaceClass",


### PR DESCRIPTION
#### Description

Now all the policies are versioned in Zookeeper. When the user modify one cube that contains the policy we increment the version number.

Cassandra output are refactored, now use the policy version for the names of the tables associated to one cube.
 
#### Reviewer

@sgomezg  @anistal @arinconstrio 
