### PR TITLE
Associative Operations

### DIFF
--- a/aggregator/src/main/scala/com/stratio/sparkta/aggregator/Cube.scala
+++ b/aggregator/src/main/scala/com/stratio/sparkta/aggregator/Cube.scala
@@ -17,83 +17,168 @@
 package com.stratio.sparkta.aggregator
 
 import java.io.{Serializable => JSerializable}
-import scala.util.Try
 
+import akka.event.slf4j.SLF4JLogging
+import com.stratio.sparkta.sdk._
+import com.stratio.sparkta.serving.core.SparktaConfig
+import com.stratio.sparkta.serving.core.constants.AppConstant
 import org.apache.spark.HashPartitioner
 import org.apache.spark.streaming.Duration
 import org.apache.spark.streaming.dstream.DStream
 import org.joda.time.DateTime
 
-import com.stratio.sparkta.sdk._
-import com.stratio.sparkta.serving.core.SparktaConfig
-import com.stratio.sparkta.serving.core.constants.AppConstant
+import scala.util.Try
 
 /**
  * Use this class to describe a cube that you want the multicube to keep.
  *
  * For example, if you're counting events with the dimensions (color, size, flavor) and you
- * want to keep a total count for all (color, size) combinations, you'd specify that using a Cube or
- * multipelexer the output
+ * want to keep a total count for all (color, size) combinations, you'd specify that using a Cube
  */
+
 case class Cube(name: String,
                 dimensions: Seq[Dimension],
                 operators: Seq[Operator],
                 checkpointTimeDimension: String,
                 checkpointInterval: Int,
                 checkpointGranularity: String,
-                checkpointTimeAvailability: Long) {
+                checkpointTimeAvailability: Long) extends SLF4JLogging {
 
-  private lazy val operatorsMap = operators.map(op => op.key -> op).toMap
+  private lazy val associativeOperators = operators.filter(op => op.associativity == MathProperties.Associative)
+  private lazy val associativeOperatorsMap = associativeOperators.map(op => op.key -> op).toMap
+  private lazy val nonAssociativeOperators = operators.filter(op => op.associativity == MathProperties.NonAssociative)
+  private lazy val nonAssociativeOperatorsMap = nonAssociativeOperators.map(op => op.key -> op).toMap
   private lazy val rememberPartitioner =
     Try(SparktaConfig.getDetailConfig.get.getBoolean(AppConstant.ConfigRememberPartitioner)).getOrElse(true)
 
   def aggregate(dimensionsValues: DStream[(DimensionValuesTime,
     Map[String, JSerializable])]): DStream[(DimensionValuesTime, Map[String, Option[Any]])] = {
     val valuesFiltered = filterDimensionValues(dimensionsValues)
-    valuesFiltered.checkpoint(new Duration(checkpointInterval))
-    aggregateValues(updateState(valuesFiltered))
+    val withAssociative = operators.exists(op => op.associativity == MathProperties.Associative)
+    val withNonAssociative = operators.exists(op => op.associativity == MathProperties.NonAssociative)
+
+    (withAssociative, withNonAssociative) match {
+      case (true, true) => {
+        val nonAssociativeValues = aggregateNonAssociativeValues(updateNonAssociativeState(valuesFiltered))
+        val associativeValues = updateAssociativeState(associativeAggregation(valuesFiltered))
+
+        associativeValues.cogroup(nonAssociativeValues)
+          .mapValues { case (associativeAggregations, nonAssociativeAggregations) =>
+            (associativeAggregations.flatten ++ nonAssociativeAggregations.flatten).toMap
+          }
+      }
+      case (true, false) => updateAssociativeState(associativeAggregation(valuesFiltered))
+      case (false, true) => aggregateNonAssociativeValues(updateNonAssociativeState(valuesFiltered))
+      case _ => {
+        log.warn("You should define operators for aggregate input values")
+        noAggregationsState(dimensionsValues)
+      }
+    }
   }
 
-  protected def filterDimensionValues(dimensionValues: DStream[(DimensionValuesTime,
-    Map[String, JSerializable])]): DStream[(DimensionValuesTime, Map[String, JSerializable])] = {
-    dimensionValues.map { case (dimensionsValuesTime, aggregationValues) => {
+  protected def filterDimensionValues(dimensionValues: DStream[(DimensionValuesTime, Map[String, JSerializable])])
+  : DStream[(DimensionValuesTime, Map[String, JSerializable])] = {
+    dimensionValues.map { case (dimensionsValuesTime, aggregationValues) =>
       val dimensionsFiltered = dimensionsValuesTime.dimensionValues.filter(dimVal =>
-        dimensions.find(comp => comp.name == dimVal.dimension.name).nonEmpty)
+        dimensions.exists(comp => comp.name == dimVal.dimension.name))
+
       (DimensionValuesTime(dimensionsFiltered, dimensionsValuesTime.time, checkpointTimeDimension), aggregationValues)
     }
-    }
   }
 
-  protected def updateState(dimensionsValues: DStream[(DimensionValuesTime, Map[String, JSerializable])]):
-  DStream[(DimensionValuesTime, Seq[(String, Option[Any])])] = {
+  protected def updateNonAssociativeState(dimensionsValues: DStream[(DimensionValuesTime, Map[String, JSerializable])])
+  : DStream[(DimensionValuesTime, Seq[(String, Option[Any])])] = {
+    dimensionsValues.checkpoint(new Duration(checkpointInterval))
+
     val newUpdateFunc = (iterator: Iterator[(DimensionValuesTime,
       Seq[Map[String, JSerializable]],
       Option[Seq[(String, Option[Any])]])]) => {
       val eventTime =
         DateOperations.dateFromGranularity(DateTime.now(), checkpointGranularity) - checkpointTimeAvailability
-      iterator.filter(dimensionsData => {
-        dimensionsData._1.time >= eventTime
-      })
+
+      iterator.filter(dimensionsData => dimensionsData._1.time >= eventTime)
         .flatMap { case (dimensionsKey, values, state) =>
-          updateFunction(values, state).map(result => (dimensionsKey, result))
+          updateNonAssociativeFunction(values, state).map(result => (dimensionsKey, result))
         }
     }
+
     dimensionsValues.updateStateByKey(
       newUpdateFunc, new HashPartitioner(dimensionsValues.context.sparkContext.defaultParallelism), rememberPartitioner)
   }
 
-  protected def updateFunction(values: Seq[Map[String, JSerializable]],
-                               state: Option[Seq[(String, Option[Any])]]): Option[Seq[(String, Option[Any])]] = {
-    val procMap = values.flatMap(inputFields =>
-      operators.flatMap(op => op.processMap(inputFields).map(op.key -> Some(_))))
-    Some(state.getOrElse(Seq()) ++ procMap)
+  protected def updateNonAssociativeFunction(values: Seq[Map[String, JSerializable]],
+                                             state: Option[Seq[(String, Option[Any])]])
+  : Option[Seq[(String, Option[Any])]] = {
+    val proccessMapValues = values.flatMap(inputFields =>
+      nonAssociativeOperators.flatMap(op => op.processMap(inputFields).map(op.key -> Some(_))))
+
+    Some(state.getOrElse(Seq()) ++ proccessMapValues)
   }
 
-  protected def aggregateValues(dimensionsValues: DStream[(DimensionValuesTime, Seq[(String, Option[Any])])]):
-  DStream[(DimensionValuesTime, Map[String, Option[Any]])] = {
+  protected def aggregateNonAssociativeValues(dimensionsValues: DStream[(DimensionValuesTime,
+    Seq[(String, Option[Any])])])
+  : DStream[(DimensionValuesTime, Map[String, Option[Any]])] =
     dimensionsValues.mapValues(aggregationValues => {
-      aggregationValues.groupBy { case (name, value) => name }
-        .map { case (name, value) => (name, operatorsMap(name).processReduce(value.map(_._2))) }
+      aggregationValues.groupBy { case (key, value) => key }
+        .map { case (name, value) =>
+          (name, nonAssociativeOperatorsMap(name).processReduce(value.map { case (opKey, opValue) => opValue }))
+        }
     })
+
+  protected def updateAssociativeState(dimensionsValues: DStream[(DimensionValuesTime, Seq[(String, Option[Any])])]):
+  DStream[(DimensionValuesTime, Map[String, Option[Any]])] = {
+    dimensionsValues.checkpoint(new Duration(checkpointInterval))
+
+    val newUpdateFunc = (iterator: Iterator[(DimensionValuesTime,
+      Seq[Seq[(String, Option[Any])]],
+      Option[Map[String, Option[Any]]])]) => {
+      val eventTime =
+        DateOperations.dateFromGranularity(DateTime.now(), checkpointGranularity) - checkpointTimeAvailability
+
+      iterator.filter(dimensionsData => dimensionsData._1.time >= eventTime)
+        .flatMap { case (dimensionsKey, values, state) =>
+          updateAssociativeFunction(values, state).map(result => (dimensionsKey, result))
+        }
+    }
+
+    dimensionsValues.updateStateByKey(
+      newUpdateFunc, new HashPartitioner(dimensionsValues.context.sparkContext.defaultParallelism), rememberPartitioner)
   }
+
+  def associativeAggregation(dimensionsValues: DStream[(DimensionValuesTime, Map[String, JSerializable])]):
+  DStream[(DimensionValuesTime, Seq[(String, Option[Any])])] =
+    dimensionsValues.mapValues(inputFields =>
+      associativeOperators.flatMap(op => op.processMap(inputFields).map(values => op.key -> Some(values))).toMap)
+      .groupByKey()
+      .map { case (dimValues, aggregations) =>
+        val aggregatedValues = aggregations.flatMap(_.toSeq).groupBy { case (opKey, opValue) => opKey }
+          .map { case (nameOp, valuesOp) =>
+            val op = associativeOperatorsMap(nameOp)
+            val values = valuesOp.map(_._2)
+            (nameOp, op.processReduce(values))
+          }.toSeq
+
+        (dimValues, aggregatedValues)
+      }
+
+  protected def updateAssociativeFunction(values: Seq[Seq[(String, Option[Any])]],
+                                          state: Option[Map[String, Option[Any]]])
+  : Option[Map[String, Option[Any]]] = {
+    val actualState = state.getOrElse(Map()).toSeq
+    val processAssociative = (values.flatten ++ actualState)
+      .groupBy { case (key, value) => key }
+      .map { case (opKey, opValues) =>
+        val op = associativeOperatorsMap(opKey)
+
+        (opKey, op.processAssociative(opValues.map { case (nameOp, valuesOp) => valuesOp }))
+      }
+
+    Some(processAssociative)
+  }
+
+  def noAggregationsState(dimensionsValues: DStream[(DimensionValuesTime, Map[String, JSerializable])])
+  : DStream[(DimensionValuesTime, Map[String, Option[Any]])] =
+    dimensionsValues.map {
+      case (dimensionValueTime, aggregations) => (dimensionValueTime, operators.map(op => op.key -> None).toMap)
+    }
 }

--- a/plugins/operator-accumulator/src/main/scala/com/stratio/sparkta/plugin/operator/accumulator/AccumulatorOperator.scala
+++ b/plugins/operator-accumulator/src/main/scala/com/stratio/sparkta/plugin/operator/accumulator/AccumulatorOperator.scala
@@ -31,11 +31,11 @@ with ProcessMapAsAny with Associative {
   override val writeOperation = WriteOp.AccSet
 
   override def processReduce(values: Iterable[Option[Any]]): Option[Any] =
-    Try(Option(getDistinctValues(values.flatten.map(_.toString)))).getOrElse(Some(""))
+    Try(Option(values.flatten.map(_.toString))).getOrElse(None)
 
   def associativity(values: Iterable[(String, Option[Any])]): Option[Any] = {
-    val newValues = getDistinctValues(extractValues(values, None))
+    val newValues = getDistinctValues(extractValues(values, None).asInstanceOf[Seq[Seq[String]]].flatten)
 
-    Try(Option(transformValueByTypeOp(returnType, newValues.map(_.toString)))).getOrElse(Some(""))
+    Try(Option(transformValueByTypeOp(returnType, newValues))).getOrElse(Option(Seq()))
   }
 }

--- a/plugins/operator-accumulator/src/main/scala/com/stratio/sparkta/plugin/operator/accumulator/AccumulatorOperator.scala
+++ b/plugins/operator-accumulator/src/main/scala/com/stratio/sparkta/plugin/operator/accumulator/AccumulatorOperator.scala
@@ -17,19 +17,25 @@
 package com.stratio.sparkta.plugin.operator.accumulator
 
 import java.io.{Serializable => JSerializable}
-import scala.util.Try
 
 import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk.{TypeOp, _}
 
+import scala.util.Try
+
 class AccumulatorOperator(name: String, properties: Map[String, JSerializable]) extends Operator(name, properties)
-with ProcessMapAsAny {
+with ProcessMapAsAny with Associative {
 
   override val defaultTypeOperation = TypeOp.ArrayString
 
   override val writeOperation = WriteOp.AccSet
 
   override def processReduce(values: Iterable[Option[Any]]): Option[Any] =
-    Try(Some(transformValueByTypeOp(returnType, getDistinctValues(values.flatten.map(_.toString)))))
-      .getOrElse(Some(""))
+    Try(Option(getDistinctValues(values.flatten.map(_.toString)))).getOrElse(Some(""))
+
+  def associativity(values: Iterable[(String, Option[Any])]): Option[Any] = {
+    val newValues = getDistinctValues(extractValues(values, None))
+
+    Try(Option(transformValueByTypeOp(returnType, newValues.map(_.toString)))).getOrElse(Some(""))
+  }
 }

--- a/plugins/operator-accumulator/src/test/scala/com/stratio/sparkta/plugin/operator/accumulator/AccumulatorOperatorTest.scala
+++ b/plugins/operator-accumulator/src/test/scala/com/stratio/sparkta/plugin/operator/accumulator/AccumulatorOperatorTest.scala
@@ -16,6 +16,7 @@
 
 package com.stratio.sparkta.plugin.operator.accumulator
 
+import com.stratio.sparkta.sdk.Operator
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{Matchers, WordSpec}
@@ -59,15 +60,6 @@ class AccumulatorOperatorTest extends WordSpec with Matchers {
       val inputFields3 = new AccumulatorOperator("accumulator", Map())
       inputFields3.processReduce(Seq(Some("a"), Some("b"))) should be(Some(Seq("a", "b")))
 
-      val inputFields4 = new AccumulatorOperator("accumulator", Map("typeOp" -> "string"))
-      inputFields4.processReduce(Seq(Some(1), Some(1))) should be(Some("1_1"))
-
-      val inputFields5 = new AccumulatorOperator("accumulator", Map("typeOp" -> "string"))
-
-      //I know, null sucks, but it's the only way test the "Try" inner
-      //scalastyle:off
-      inputFields5.processReduce(null) should be(Some(""))
-      //scalastyle:on
     }
 
     "processReduce distinct must be " in {
@@ -80,8 +72,25 @@ class AccumulatorOperatorTest extends WordSpec with Matchers {
       val inputFields3 = new AccumulatorOperator("accumulator", Map("distinct" -> "true"))
       inputFields3.processReduce(Seq(Some("a"), Some("b"))) should be(Some(Seq("a", "b")))
 
-      val inputFields4 = new AccumulatorOperator("accumulator", Map("typeOp" -> "string", "distinct" -> "true"))
-      inputFields4.processReduce(Seq(Some(1), Some(1))) should be(Some("1"))
+    }
+
+    "associative process must be " in {
+      val inputFields = new AccumulatorOperator("accumulator", Map())
+      val resultInput = Seq((Operator.OldValuesKey, Some(1L)),
+        (Operator.NewValuesKey, Some(2L)),
+        (Operator.NewValuesKey, None))
+      inputFields.associativity(resultInput) should be(Some(Seq("1", "2")))
+
+      val inputFields2 = new AccumulatorOperator("accumulator", Map("typeOp" -> "arraydouble"))
+      val resultInput2 = Seq((Operator.OldValuesKey, Some(1)),
+        (Operator.NewValuesKey, Some(3)))
+      inputFields2.associativity(resultInput2) should be(Some(Seq(1d, 3d)))
+
+      val inputFields3 = new AccumulatorOperator("accumulator", Map("typeOp" -> null))
+      val resultInput3 = Seq((Operator.OldValuesKey, Some(1)),
+        (Operator.NewValuesKey, Some(1)))
+      inputFields3.associativity(resultInput3) should be(Some(Seq("1", "1")))
+
     }
   }
 }

--- a/plugins/operator-accumulator/src/test/scala/com/stratio/sparkta/plugin/operator/accumulator/AccumulatorOperatorTest.scala
+++ b/plugins/operator-accumulator/src/test/scala/com/stratio/sparkta/plugin/operator/accumulator/AccumulatorOperatorTest.scala
@@ -62,33 +62,21 @@ class AccumulatorOperatorTest extends WordSpec with Matchers {
 
     }
 
-    "processReduce distinct must be " in {
-      val inputFields = new AccumulatorOperator("accumulator", Map("distinct" -> "true"))
-      inputFields.processReduce(Seq()) should be(Some(Seq()))
-
-      val inputFields2 = new AccumulatorOperator("accumulator", Map("distinct" -> "true"))
-      inputFields2.processReduce(Seq(Some(1), Some(1))) should be(Some(Seq("1")))
-
-      val inputFields3 = new AccumulatorOperator("accumulator", Map("distinct" -> "true"))
-      inputFields3.processReduce(Seq(Some("a"), Some("b"))) should be(Some(Seq("a", "b")))
-
-    }
-
     "associative process must be " in {
       val inputFields = new AccumulatorOperator("accumulator", Map())
-      val resultInput = Seq((Operator.OldValuesKey, Some(1L)),
-        (Operator.NewValuesKey, Some(2L)),
+      val resultInput = Seq((Operator.OldValuesKey, Some(Seq(1L))),
+        (Operator.NewValuesKey, Some(Seq(2L))),
         (Operator.NewValuesKey, None))
       inputFields.associativity(resultInput) should be(Some(Seq("1", "2")))
 
       val inputFields2 = new AccumulatorOperator("accumulator", Map("typeOp" -> "arraydouble"))
-      val resultInput2 = Seq((Operator.OldValuesKey, Some(1)),
-        (Operator.NewValuesKey, Some(3)))
+      val resultInput2 = Seq((Operator.OldValuesKey, Some(Seq(1))),
+        (Operator.NewValuesKey, Some(Seq(3))))
       inputFields2.associativity(resultInput2) should be(Some(Seq(1d, 3d)))
 
       val inputFields3 = new AccumulatorOperator("accumulator", Map("typeOp" -> null))
-      val resultInput3 = Seq((Operator.OldValuesKey, Some(1)),
-        (Operator.NewValuesKey, Some(1)))
+      val resultInput3 = Seq((Operator.OldValuesKey, Some(Seq(1))),
+        (Operator.NewValuesKey, Some(Seq(1))))
       inputFields3.associativity(resultInput3) should be(Some(Seq("1", "1")))
 
     }

--- a/plugins/operator-avg/src/test/scala/com/stratio/sparkta/plugin/operator/avg/AvgOperatorTest.scala
+++ b/plugins/operator-avg/src/test/scala/com/stratio/sparkta/plugin/operator/avg/AvgOperatorTest.scala
@@ -56,8 +56,10 @@ class AvgOperatorTest extends WordSpec with Matchers {
       inputFields9.processMap(Map("field1" -> 1, "field2" -> 2)) should be(None)
 
       val inputFields10 = new AvgOperator("avg",
-        Map("inputField" -> "field1", "filters" -> {"[{\"field\":\"field1\", \"type\": \"<\", \"value\":\"2\"}," +
-          "{\"field\":\"field2\", \"type\": \"<\", \"value\":\"2\"}]"}))
+        Map("inputField" -> "field1", "filters" -> {
+          "[{\"field\":\"field1\", \"type\": \"<\", \"value\":\"2\"}," +
+            "{\"field\":\"field2\", \"type\": \"<\", \"value\":\"2\"}]"
+        }))
       inputFields10.processMap(Map("field1" -> 1, "field2" -> 2)) should be(None)
     }
 
@@ -76,7 +78,6 @@ class AvgOperatorTest extends WordSpec with Matchers {
 
       val inputFields5 = new AvgOperator("avg", Map("typeOp" -> "string"))
       inputFields5.processReduce(Seq(Some(1), Some(1))) should be(Some("1.0"))
-
     }
 
     "processReduce distinct must be " in {
@@ -94,7 +95,6 @@ class AvgOperatorTest extends WordSpec with Matchers {
 
       val inputFields5 = new AvgOperator("avg", Map("typeOp" -> "string", "distinct" -> "true"))
       inputFields5.processReduce(Seq(Some(1), Some(1))) should be(Some("1.0"))
-
     }
   }
 }

--- a/plugins/operator-count/src/main/scala/com/stratio/sparkta/plugin/operator/count/CountOperator.scala
+++ b/plugins/operator-count/src/main/scala/com/stratio/sparkta/plugin/operator/count/CountOperator.scala
@@ -25,11 +25,9 @@ import com.stratio.sparkta.sdk.{TypeOp, _}
 import scala.util.Try
 
 class CountOperator(name: String, properties: Map[String, JSerializable])
-  extends Operator(name, properties) {
+  extends Operator(name, properties) with Associative {
 
   val distinctFields = parseDistinctFields
-
-  override val associativity = MathProperties.Associative
 
   override val defaultTypeOperation = TypeOp.Long
 
@@ -39,8 +37,8 @@ class CountOperator(name: String, properties: Map[String, JSerializable])
 
   override def processMap(inputFields: Map[String, JSerializable]): Option[Any] = {
     applyFilters(inputFields).flatMap(filteredFields => distinctFields match {
-      case None => Some(CountOperator.One.toLong)
-      case Some(fields) => Some(fields.map(field => filteredFields.getOrElse(field, CountOperator.NullValue))
+      case None => Option(CountOperator.One.toLong)
+      case Some(fields) => Option(fields.map(field => filteredFields.getOrElse(field, CountOperator.NullValue))
         .mkString(OperatorConstants.UnderscoreSeparator).toString)
     })
   }
@@ -51,19 +49,22 @@ class CountOperator(name: String, properties: Map[String, JSerializable])
         case None => values.flatten.map(value => value.asInstanceOf[Number].longValue())
         case Some(fields) => values.flatten.toList.distinct.map(value => CountOperator.One.toLong)
       }
-      Some(longList.sum)
-    }.getOrElse(Some(OperatorConstants.Zero.toLong))
+      Option(longList.sum)
+    }.getOrElse(Option(OperatorConstants.Zero.toLong))
   }
 
-  override def processAssociative(values: Iterable[Option[Any]]): Option[Long] = {
-    Some(transformValueByTypeOp(returnType, values.flatten.map(_.asInstanceOf[Number].longValue()).sum))
+  def associativity(values: Iterable[(String, Option[Any])]): Option[Long] = {
+    val newValues = extractValues(values, None).map(_.asInstanceOf[Number].longValue()).sum
+
+    Try(Option(transformValueByTypeOp(returnType, newValues)))
+      .getOrElse(Option(OperatorConstants.Zero.toLong))
   }
 
   //FIXME: We should refactor this code
   private def parseDistinctFields: Option[Seq[String]] = {
     val distinct = properties.getString("distinctFields", None)
     if (distinct.isDefined && !distinct.get.isEmpty)
-      Some(distinct.get.split(OperatorConstants.UnderscoreSeparator))
+      Option(distinct.get.split(OperatorConstants.UnderscoreSeparator))
     else None
   }
 }

--- a/plugins/operator-count/src/main/scala/com/stratio/sparkta/plugin/operator/count/CountOperator.scala
+++ b/plugins/operator-count/src/main/scala/com/stratio/sparkta/plugin/operator/count/CountOperator.scala
@@ -17,16 +17,19 @@
 package com.stratio.sparkta.plugin.operator.count
 
 import java.io.{Serializable => JSerializable}
-import scala.util.Try
 
 import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk.ValidatingPropertyMap._
 import com.stratio.sparkta.sdk.{TypeOp, _}
 
+import scala.util.Try
+
 class CountOperator(name: String, properties: Map[String, JSerializable])
   extends Operator(name, properties) {
 
   val distinctFields = parseDistinctFields
+
+  override val associativity = MathProperties.Associative
 
   override val defaultTypeOperation = TypeOp.Long
 
@@ -48,8 +51,12 @@ class CountOperator(name: String, properties: Map[String, JSerializable])
         case None => values.flatten.map(value => value.asInstanceOf[Number].longValue())
         case Some(fields) => values.flatten.toList.distinct.map(value => CountOperator.One.toLong)
       }
-      Some(transformValueByTypeOp(returnType, longList.sum))
+      Some(longList.sum)
     }.getOrElse(Some(OperatorConstants.Zero.toLong))
+  }
+
+  override def processAssociative(values: Iterable[Option[Any]]): Option[Long] = {
+    Some(transformValueByTypeOp(returnType, values.flatten.map(_.asInstanceOf[Number].longValue()).sum))
   }
 
   //FIXME: We should refactor this code

--- a/plugins/operator-count/src/test/scala/com.stratio.sparkta.plugin.operator.count/CountOperatorTest.scala
+++ b/plugins/operator-count/src/test/scala/com.stratio.sparkta.plugin.operator.count/CountOperatorTest.scala
@@ -16,7 +16,7 @@
 
 package com.stratio.sparkta.plugin.operator.count
 
-import com.stratio.sparkta.sdk.OperatorConstants
+import com.stratio.sparkta.sdk._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{Matchers, WordSpec}
@@ -101,13 +101,18 @@ class CountOperatorTest extends WordSpec with Matchers {
 
     "associative process must be " in {
       val inputFields = new CountOperator("count", Map())
-      inputFields.processAssociative(Seq(Some(1L), Some(1L), None)) should be(Some(2L))
+      val resultInput = Seq((Operator.OldValuesKey, Some(1L)),
+        (Operator.NewValuesKey, Some(1L)),
+        (Operator.NewValuesKey, None))
+      inputFields.associativity(resultInput) should be(Some(2L))
 
       val inputFields2 = new CountOperator("count", Map("typeOp" -> "string"))
-      inputFields2.processAssociative(Seq(Some(1), Some(1))) should be(Some("2"))
+      val resultInput2 = Seq((Operator.OldValuesKey, Some(1L)), (Operator.NewValuesKey, Some(1L)))
+      inputFields2.associativity(resultInput2) should be(Some("2"))
 
       val inputFields3 = new CountOperator("count", Map("typeOp" -> null))
-      inputFields3.processAssociative(Seq(Some(1), Some(1))) should be(Some(2))
+      val resultInput3 = Seq((Operator.OldValuesKey, Some(1L)), (Operator.NewValuesKey, Some(1L)))
+      inputFields3.associativity(resultInput3) should be(Some(2))
     }
   }
 }

--- a/plugins/operator-count/src/test/scala/com.stratio.sparkta.plugin.operator.count/CountOperatorTest.scala
+++ b/plugins/operator-count/src/test/scala/com.stratio.sparkta.plugin.operator.count/CountOperatorTest.scala
@@ -16,11 +16,10 @@
 
 package com.stratio.sparkta.plugin.operator.count
 
+import com.stratio.sparkta.sdk.OperatorConstants
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{Matchers, WordSpec}
-
-import com.stratio.sparkta.sdk.OperatorConstants
 
 @RunWith(classOf[JUnitRunner])
 class CountOperatorTest extends WordSpec with Matchers {
@@ -88,7 +87,7 @@ class CountOperatorTest extends WordSpec with Matchers {
         Some(s"field1${OperatorConstants.UnderscoreSeparator}field3"))) should be(Some(2L))
 
       val inputFields5 = new CountOperator("count", Map("typeOp" -> "string"))
-      inputFields5.processReduce(Seq(Some(1), Some(1))) should be(Some("2"))
+      inputFields5.processReduce(Seq(Some(1), Some(1))) should be(Some(2))
 
       val inputFields6 =
         new CountOperator("count", Map("distinctFields" -> s"field1${OperatorConstants.UnderscoreSeparator}field2"))
@@ -97,7 +96,18 @@ class CountOperatorTest extends WordSpec with Matchers {
         Some(s"field1${OperatorConstants.UnderscoreSeparator}field3"))) should be(Some(2L))
 
       val inputFields7 = new CountOperator("count", Map("typeOp" -> null))
-      inputFields7.processReduce(Seq(Some(1), Some(1))) should be(Some(0))
+      inputFields7.processReduce(Seq(Some(1), Some(1))) should be(Some(2))
+    }
+
+    "associative process must be " in {
+      val inputFields = new CountOperator("count", Map())
+      inputFields.processAssociative(Seq(Some(1L), Some(1L), None)) should be(Some(2L))
+
+      val inputFields2 = new CountOperator("count", Map("typeOp" -> "string"))
+      inputFields2.processAssociative(Seq(Some(1), Some(1))) should be(Some("2"))
+
+      val inputFields3 = new CountOperator("count", Map("typeOp" -> null))
+      inputFields3.processAssociative(Seq(Some(1), Some(1))) should be(Some(2))
     }
   }
 }

--- a/plugins/operator-entityCount/src/main/scala/com/stratio/sparkta/plugin/operator/entityCount/EntityCountOperator.scala
+++ b/plugins/operator-entityCount/src/main/scala/com/stratio/sparkta/plugin/operator/entityCount/EntityCountOperator.scala
@@ -41,15 +41,19 @@ class EntityCountOperator(name: String, properties: Map[String, JSerializable])
       .flatMap(_.asInstanceOf[Map[String, Long]]).toList
     val newValues = applyCount(extractValues(values, Option(Operator.NewValuesKey))
       .flatMap(_.asInstanceOf[Seq[String]]).toList).toList
+    val wordCounts = applyCountMerge(oldValues ++ newValues)
 
-    Try(Option(transformValueByTypeOp(returnType, applyCountMerge(oldValues ++ newValues)))).getOrElse(Option(Map()))
+    Try(Option(transformValueByTypeOp(returnType, wordCounts)))
+      .getOrElse(Option(Map()))
   }
 
   private def applyCount(values: List[String]): Map[String, Long] =
     values.groupBy((word: String) => word).mapValues(_.length.toLong)
 
   private def applyCountMerge(values: List[(String, Long)]): Map[String, Long] =
-    values.groupBy { case (word, count) => word }.mapValues(_.map { case (key, value) => value }.sum)
+    values.groupBy { case (word, count) => word }.mapValues {
+      listValues => listValues.map { case (key, value) => value }.sum
+    }
 }
 
 

--- a/plugins/operator-entityCount/src/test/scala/com/stratio/sparkta/plugin/operator/entityCount/EntityCountOperatorTest.scala
+++ b/plugins/operator-entityCount/src/test/scala/com/stratio/sparkta/plugin/operator/entityCount/EntityCountOperatorTest.scala
@@ -16,6 +16,7 @@
 
 package com.stratio.sparkta.plugin.operator.entityCount
 
+import com.stratio.sparkta.sdk.Operator
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{Matchers, WordSpec}
@@ -39,11 +40,11 @@ class EntityCountOperatorTest extends WordSpec with Matchers {
       inputFields4.processMap(Map("field1" -> "hola holo", "field2" -> 2)) should be(Some(Seq("hola holo")))
 
       val inputFields5 = new EntityCountOperator("entityCount", Map("inputField" -> "field1", "split" -> "-"))
-      inputFields5.processMap(Map("field1" -> "hola-holo", "field2" -> 2)) should be(Some(Seq("hola","holo")))
+      inputFields5.processMap(Map("field1" -> "hola-holo", "field2" -> 2)) should be(Some(Seq("hola", "holo")))
 
       val inputFields6 = new EntityCountOperator("entityCount", Map("inputField" -> "field1", "split" -> ","))
       inputFields6.processMap(Map("field1" -> "hola,holo adios", "field2" -> 2)) should be(
-        Some(Seq("hola","holo " + "adios")))
+        Some(Seq("hola", "holo " + "adios")))
 
       val inputFields7 = new EntityCountOperator("entityCount",
         Map("inputField" -> "field1", "filters" -> "[{\"field\":\"field1\", \"type\": \"!=\", \"value\":\"hola\"}]"))
@@ -52,8 +53,7 @@ class EntityCountOperatorTest extends WordSpec with Matchers {
       val inputFields8 = new EntityCountOperator("entityCount",
         Map("inputField" -> "field1", "filters" -> "[{\"field\":\"field1\", \"type\": \"!=\", \"value\":\"hola\"}]",
           "split" -> " "))
-      inputFields8.processMap(Map("field1" -> "hola holo", "field2" -> 2)) should be(Some(Seq("hola","holo")))
-
+      inputFields8.processMap(Map("field1" -> "hola holo", "field2" -> 2)) should be(Some(Seq("hola", "holo")))
     }
 
     "processReduce must be " in {
@@ -61,10 +61,10 @@ class EntityCountOperatorTest extends WordSpec with Matchers {
       inputFields.processReduce(Seq()) should be(Some(Map()))
 
       val inputFields2 = new EntityCountOperator("entityCount", Map())
-      inputFields2.processReduce(Seq(Some(Seq("hola", "holo")))) should be (Some(Map("hola" -> 1, "holo" -> 1)))
+      inputFields2.processReduce(Seq(Some(Seq("hola", "holo")))) should be(Some(Map("hola" -> 1, "holo" -> 1)))
 
       val inputFields3 = new EntityCountOperator("entityCount", Map())
-      inputFields3.processReduce(Seq(Some(Seq("hola", "holo", "hola")))) should be (Some(Map("hola" -> 2, "holo" -> 1)))
+      inputFields3.processReduce(Seq(Some(Seq("hola", "holo", "hola")))) should be(Some(Map("hola" -> 2, "holo" -> 1)))
     }
 
     "processReduce distinct must be " in {
@@ -72,9 +72,22 @@ class EntityCountOperatorTest extends WordSpec with Matchers {
       inputFields.processReduce(Seq()) should be(Some(Map()))
 
       val inputFields2 = new EntityCountOperator("entityCount", Map("distinct" -> "true"))
-      inputFields2.processReduce(Seq(Some(Seq("hola", "holo", "hola")))) should be (Some(Map("hola" -> 1, "holo" -> 1)))
+      inputFields2.processReduce(Seq(Some(Seq("hola", "holo", "hola")))) should be(Some(Map("hola" -> 1, "holo" -> 1)))
+    }
 
+    "associative process must be " in {
+      val inputFields = new EntityCountOperator("entityCount", Map())
+      val resultInput = Seq((Operator.OldValuesKey, Some(Seq("hola", "holo"))), (Operator.NewValuesKey, None))
+      inputFields.associativity(resultInput) should be(Some(Map("hola" -> 1, "holo" -> 1)))
+
+      val inputFields2 = new EntityCountOperator("entityCount", Map("typeOp" -> "int"))
+      val resultInput2 = Seq((Operator.OldValuesKey, Some(Seq("hola", "holo"))),
+        (Operator.NewValuesKey, Some(Seq("hola"))))
+      inputFields2.associativity(resultInput2) should be(Some(Map("hola" -> 2, "holo" -> 1)))
+
+      val inputFields3 = new EntityCountOperator("entityCount", Map("typeOp" -> null))
+      val resultInput3 = Seq((Operator.OldValuesKey, Some(Seq("hola", "holo"))))
+      inputFields3.associativity(resultInput3) should be(Some(Map("hola" -> 1, "holo" -> 1)))
     }
   }
-
 }

--- a/plugins/operator-entityCount/src/test/scala/com/stratio/sparkta/plugin/operator/entityCount/EntityCountOperatorTest.scala
+++ b/plugins/operator-entityCount/src/test/scala/com/stratio/sparkta/plugin/operator/entityCount/EntityCountOperatorTest.scala
@@ -58,36 +58,29 @@ class EntityCountOperatorTest extends WordSpec with Matchers {
 
     "processReduce must be " in {
       val inputFields = new EntityCountOperator("entityCount", Map())
-      inputFields.processReduce(Seq()) should be(Some(Map()))
+      inputFields.processReduce(Seq()) should be(Some(Seq()))
 
       val inputFields2 = new EntityCountOperator("entityCount", Map())
-      inputFields2.processReduce(Seq(Some(Seq("hola", "holo")))) should be(Some(Map("hola" -> 1, "holo" -> 1)))
+      inputFields2.processReduce(Seq(Some(Seq("hola", "holo")))) should be(Some(Seq("hola", "holo")))
 
       val inputFields3 = new EntityCountOperator("entityCount", Map())
-      inputFields3.processReduce(Seq(Some(Seq("hola", "holo", "hola")))) should be(Some(Map("hola" -> 2, "holo" -> 1)))
-    }
-
-    "processReduce distinct must be " in {
-      val inputFields = new EntityCountOperator("entityCount", Map("distinct" -> "true"))
-      inputFields.processReduce(Seq()) should be(Some(Map()))
-
-      val inputFields2 = new EntityCountOperator("entityCount", Map("distinct" -> "true"))
-      inputFields2.processReduce(Seq(Some(Seq("hola", "holo", "hola")))) should be(Some(Map("hola" -> 1, "holo" -> 1)))
+      inputFields3.processReduce(Seq(Some(Seq("hola", "holo", "hola")))) should be(Some(Seq("hola", "holo", "hola")))
     }
 
     "associative process must be " in {
       val inputFields = new EntityCountOperator("entityCount", Map())
-      val resultInput = Seq((Operator.OldValuesKey, Some(Seq("hola", "holo"))), (Operator.NewValuesKey, None))
-      inputFields.associativity(resultInput) should be(Some(Map("hola" -> 1, "holo" -> 1)))
+      val resultInput = Seq((Operator.OldValuesKey, Some(Map("hola" -> 1L, "holo" -> 1L))),
+        (Operator.NewValuesKey, None))
+      inputFields.associativity(resultInput) should be(Some(Map("hola" -> 1L, "holo" -> 1L)))
 
       val inputFields2 = new EntityCountOperator("entityCount", Map("typeOp" -> "int"))
-      val resultInput2 = Seq((Operator.OldValuesKey, Some(Seq("hola", "holo"))),
+      val resultInput2 = Seq((Operator.OldValuesKey, Some(Map("hola" -> 1L, "holo" -> 1L))),
         (Operator.NewValuesKey, Some(Seq("hola"))))
-      inputFields2.associativity(resultInput2) should be(Some(Map("hola" -> 2, "holo" -> 1)))
+      inputFields2.associativity(resultInput2) should be(Some(Map("hola" -> 2L, "holo" -> 1L)))
 
       val inputFields3 = new EntityCountOperator("entityCount", Map("typeOp" -> null))
-      val resultInput3 = Seq((Operator.OldValuesKey, Some(Seq("hola", "holo"))))
-      inputFields3.associativity(resultInput3) should be(Some(Map("hola" -> 1, "holo" -> 1)))
+      val resultInput3 = Seq((Operator.OldValuesKey, Some(Map("hola" -> 1L, "holo" -> 1L))))
+      inputFields3.associativity(resultInput3) should be(Some(Map("hola" -> 1L, "holo" -> 1L)))
     }
   }
 }

--- a/plugins/operator-firstValue/src/main/scala/com/stratio/sparkta/plugin/operator/firstValue/FirstValueOperator.scala
+++ b/plugins/operator-firstValue/src/main/scala/com/stratio/sparkta/plugin/operator/firstValue/FirstValueOperator.scala
@@ -17,19 +17,25 @@
 package com.stratio.sparkta.plugin.operator.firstValue
 
 import java.io.{Serializable => JSerializable}
-import scala.util.Try
 
 import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk.{TypeOp, _}
 
+import scala.util.Try
+
 class FirstValueOperator(name: String, properties: Map[String, JSerializable]) extends Operator(name, properties)
-with ProcessMapAsAny {
+with ProcessMapAsAny with Associative {
 
   override val defaultTypeOperation = TypeOp.String
 
   override val writeOperation = WriteOp.Set
 
   override def processReduce(values: Iterable[Option[Any]]): Option[Any] =
-    Try(Some(transformValueByTypeOp(returnType, values.flatten.head)))
-      .getOrElse(Some(OperatorConstants.EmptyString))
+    Try(Option(values.flatten.head)).getOrElse(Some(OperatorConstants.EmptyString))
+
+  def associativity(values: Iterable[(String, Option[Any])]): Option[Any] = {
+    val oldValues = getDistinctValues(extractValues(values, Option(Operator.OldValuesKey)))
+
+    Try(Option(transformValueByTypeOp(returnType, oldValues.head))).getOrElse(Option(OperatorConstants.EmptyString))
+  }
 }

--- a/plugins/operator-firstValue/src/main/scala/com/stratio/sparkta/plugin/operator/firstValue/FirstValueOperator.scala
+++ b/plugins/operator-firstValue/src/main/scala/com/stratio/sparkta/plugin/operator/firstValue/FirstValueOperator.scala
@@ -34,8 +34,10 @@ with ProcessMapAsAny with Associative {
     Try(Option(values.flatten.head)).getOrElse(Some(OperatorConstants.EmptyString))
 
   def associativity(values: Iterable[(String, Option[Any])]): Option[Any] = {
-    val oldValues = getDistinctValues(extractValues(values, Option(Operator.OldValuesKey)))
+    val oldValues = extractValues(values, Option(Operator.OldValuesKey))
+    val firstValue = if(oldValues.nonEmpty) oldValues
+    else extractValues(values, Option(Operator.NewValuesKey))
 
-    Try(Option(transformValueByTypeOp(returnType, oldValues.head))).getOrElse(Option(OperatorConstants.EmptyString))
+    Try(Option(transformValueByTypeOp(returnType, firstValue.head))).getOrElse(Option(OperatorConstants.EmptyString))
   }
 }

--- a/plugins/operator-firstValue/src/test/scala/com/stratio/sparkta/plugin/operator/firstValue/FirstValueOperatorTest.scala
+++ b/plugins/operator-firstValue/src/test/scala/com/stratio/sparkta/plugin/operator/firstValue/FirstValueOperatorTest.scala
@@ -16,11 +16,10 @@
 
 package com.stratio.sparkta.plugin.operator.firstValue
 
+import com.stratio.sparkta.sdk.Operator
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{Matchers, WordSpec}
-
-import com.stratio.sparkta.sdk.TypeOp
 
 @RunWith(classOf[JUnitRunner])
 class FirstValueOperatorTest extends WordSpec with Matchers {
@@ -55,14 +54,30 @@ class FirstValueOperatorTest extends WordSpec with Matchers {
       val inputFields = new FirstValueOperator("firstValue", Map())
       inputFields.processReduce(Seq()) should be(Some(""))
 
-      val inputFields2 = new FirstValueOperator("firstValue", Map("typeOp" -> "int"))
+      val inputFields2 = new FirstValueOperator("firstValue", Map())
       inputFields2.processReduce(Seq(Some(1), Some(2))) should be(Some(1))
-
-      val inputFields4 = new FirstValueOperator("firstValue", Map("typeOp" -> "string"))
-      inputFields4.processReduce(Seq(Some(1), Some(2))) should be(Some("1"))
 
       val inputFields3 = new FirstValueOperator("firstValue", Map())
       inputFields3.processReduce(Seq(Some("a"), Some("b"))) should be(Some("a"))
+    }
+
+    "associative process must be " in {
+      val inputFields = new FirstValueOperator("firstValue", Map())
+      val resultInput = Seq((Operator.OldValuesKey, Some(1L)),
+        (Operator.NewValuesKey, Some(1L)),
+        (Operator.NewValuesKey, None))
+      inputFields.associativity(resultInput) should be(Some("1"))
+
+      val inputFields2 = new FirstValueOperator("firstValue", Map("typeOp" -> "int"))
+      val resultInput2 = Seq((Operator.OldValuesKey, Some(1L)),
+        (Operator.NewValuesKey, Some(1L)))
+      inputFields2.associativity(resultInput2) should be(Some(1))
+
+      val inputFields3 = new FirstValueOperator("firstValue", Map("typeOp" -> null))
+      val resultInput3 = Seq((Operator.OldValuesKey, Some(1)),
+        (Operator.NewValuesKey, Some(1)),
+        (Operator.NewValuesKey, None))
+      inputFields3.associativity(resultInput3) should be(Some("1"))
     }
   }
 }

--- a/plugins/operator-fullText/src/main/scala/com/stratio/sparkta/plugin/operator/fullText/FullTextOperator.scala
+++ b/plugins/operator-fullText/src/main/scala/com/stratio/sparkta/plugin/operator/fullText/FullTextOperator.scala
@@ -17,21 +17,28 @@
 package com.stratio.sparkta.plugin.operator.fullText
 
 import java.io.{Serializable => JSerializable}
-import scala.util.Try
 
 import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk.{TypeOp, _}
 
+import scala.util.Try
+
 class FullTextOperator(name: String, properties: Map[String, JSerializable]) extends Operator(name, properties)
-with ProcessMapAsAny {
+with ProcessMapAsAny with Associative {
 
   override val defaultTypeOperation = TypeOp.String
 
   override val writeOperation = WriteOp.FullText
 
   override def processReduce(values: Iterable[Option[Any]]): Option[String] = {
-    Try(Some(transformValueByTypeOp(returnType,
-      values.flatten.map(_.toString).reduce(_ + OperatorConstants.SpaceSeparator + _))))
+    Try(Option(values.flatten.map(_.toString).mkString(OperatorConstants.SpaceSeparator)))
+      .getOrElse(Some(OperatorConstants.EmptyString))
+  }
+
+  def associativity(values: Iterable[(String, Option[Any])]): Option[String] = {
+    val newValues = extractValues(values, None).map(_.toString).mkString(OperatorConstants.SpaceSeparator)
+
+    Try(Option(transformValueByTypeOp(returnType, newValues)))
       .getOrElse(Some(OperatorConstants.EmptyString))
   }
 }

--- a/plugins/operator-fullText/src/test/scala/com/stratio/sparkta/plugin/operator/fullText/FullTextOperatorTest.scala
+++ b/plugins/operator-fullText/src/test/scala/com/stratio/sparkta/plugin/operator/fullText/FullTextOperatorTest.scala
@@ -16,11 +16,10 @@
 
 package com.stratio.sparkta.plugin.operator.fullText
 
+import com.stratio.sparkta.sdk.OperatorConstants
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{Matchers, WordSpec}
-
-import com.stratio.sparkta.sdk.OperatorConstants
 
 @RunWith(classOf[JUnitRunner])
 class FullTextOperatorTest extends WordSpec with Matchers {
@@ -46,8 +45,10 @@ class FullTextOperatorTest extends WordSpec with Matchers {
       inputFields5.processMap(Map("field1" -> 1, "field2" -> 2)) should be(None)
 
       val inputFields6 = new FullTextOperator("fullText",
-        Map("inputField" -> "field1", "filters" -> {"[{\"field\":\"field1\", \"type\": \"<\", \"value\":\"2\"}," +
-          "{\"field\":\"field2\", \"type\": \"<\", \"value\":\"2\"}]"}))
+        Map("inputField" -> "field1", "filters" -> {
+          "[{\"field\":\"field1\", \"type\": \"<\", \"value\":\"2\"}," +
+            "{\"field\":\"field2\", \"type\": \"<\", \"value\":\"2\"}]"
+        }))
       inputFields6.processMap(Map("field1" -> 1, "field2" -> 2)) should be(None)
     }
 

--- a/plugins/operator-fullText/src/test/scala/com/stratio/sparkta/plugin/operator/fullText/FullTextOperatorTest.scala
+++ b/plugins/operator-fullText/src/test/scala/com/stratio/sparkta/plugin/operator/fullText/FullTextOperatorTest.scala
@@ -16,7 +16,7 @@
 
 package com.stratio.sparkta.plugin.operator.fullText
 
-import com.stratio.sparkta.sdk.OperatorConstants
+import com.stratio.sparkta.sdk.{Operator, OperatorConstants}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{Matchers, WordSpec}
@@ -61,9 +61,21 @@ class FullTextOperatorTest extends WordSpec with Matchers {
 
       val inputFields3 = new FullTextOperator("fullText", Map())
       inputFields3.processReduce(Seq(Some("a"), Some("b"))) should be(Some(s"a${OperatorConstants.SpaceSeparator}b"))
+    }
 
-      val inputFields4 = new FullTextOperator("fullText", Map("typeOp" -> "arraystring"))
-      inputFields4.processReduce(Seq(Some(1), Some(1))) should be(Some(Seq(s"1${OperatorConstants.SpaceSeparator}1")))
+    "associative process must be " in {
+      val inputFields = new FullTextOperator("fullText", Map())
+      val resultInput = Seq((Operator.OldValuesKey, Some(2)), (Operator.NewValuesKey, None))
+      inputFields.associativity(resultInput) should be(Some("2"))
+
+      val inputFields2 = new FullTextOperator("fullText", Map("typeOp" -> "arraystring"))
+      val resultInput2 = Seq((Operator.OldValuesKey, Some(2)),
+        (Operator.NewValuesKey, Some(1)))
+      inputFields2.associativity(resultInput2) should be(Some(Seq(s"2${OperatorConstants.SpaceSeparator}1")))
+
+      val inputFields3 = new FullTextOperator("fullText", Map("typeOp" -> null))
+      val resultInput3 = Seq((Operator.OldValuesKey, Some(2)), (Operator.OldValuesKey, Some(3)))
+      inputFields3.associativity(resultInput3) should be(Some(s"2${OperatorConstants.SpaceSeparator}3"))
     }
   }
 }

--- a/plugins/operator-lastValue/src/main/scala/com/stratio/sparkta/plugin/operator/lastValue/LastValueOperator.scala
+++ b/plugins/operator-lastValue/src/main/scala/com/stratio/sparkta/plugin/operator/lastValue/LastValueOperator.scala
@@ -17,19 +17,25 @@
 package com.stratio.sparkta.plugin.operator.lastValue
 
 import java.io.{Serializable => JSerializable}
-import scala.util.Try
 
 import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk.{TypeOp, _}
 
+import scala.util.Try
+
 class LastValueOperator(name: String, properties: Map[String, JSerializable]) extends Operator(name, properties)
-with ProcessMapAsAny {
+with ProcessMapAsAny with Associative {
 
   override val defaultTypeOperation = TypeOp.String
 
   override val writeOperation = WriteOp.Set
 
   override def processReduce(values: Iterable[Option[Any]]): Option[Any] =
-    Try(Some(transformValueByTypeOp(returnType, values.flatten.last)))
-      .getOrElse(Some(OperatorConstants.EmptyString))
+    Try(Option(values.flatten.last)).getOrElse(Some(OperatorConstants.EmptyString))
+
+  def associativity(values: Iterable[(String, Option[Any])]): Option[Any] = {
+    val oldValues = getDistinctValues(extractValues(values, Option(Operator.NewValuesKey)))
+
+    Try(Option(transformValueByTypeOp(returnType, oldValues.last))).getOrElse(Option(OperatorConstants.EmptyString))
+  }
 }

--- a/plugins/operator-lastValue/src/main/scala/com/stratio/sparkta/plugin/operator/lastValue/LastValueOperator.scala
+++ b/plugins/operator-lastValue/src/main/scala/com/stratio/sparkta/plugin/operator/lastValue/LastValueOperator.scala
@@ -34,8 +34,10 @@ with ProcessMapAsAny with Associative {
     Try(Option(values.flatten.last)).getOrElse(Some(OperatorConstants.EmptyString))
 
   def associativity(values: Iterable[(String, Option[Any])]): Option[Any] = {
-    val oldValues = getDistinctValues(extractValues(values, Option(Operator.NewValuesKey)))
+    val newValues = extractValues(values, Option(Operator.NewValuesKey))
+    val lastValue = if(newValues.nonEmpty) newValues
+    else extractValues(values, Option(Operator.OldValuesKey))
 
-    Try(Option(transformValueByTypeOp(returnType, oldValues.last))).getOrElse(Option(OperatorConstants.EmptyString))
+    Try(Option(transformValueByTypeOp(returnType, lastValue.last))).getOrElse(Option(OperatorConstants.EmptyString))
   }
 }

--- a/plugins/operator-lastValue/src/test/scala/com/stratio/sparkta/plugin/operator/lastValue/LastValueOperatorTest.scala
+++ b/plugins/operator-lastValue/src/test/scala/com/stratio/sparkta/plugin/operator/lastValue/LastValueOperatorTest.scala
@@ -16,6 +16,7 @@
 
 package com.stratio.sparkta.plugin.operator.lastValue
 
+import com.stratio.sparkta.sdk.Operator
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{Matchers, WordSpec}
@@ -53,14 +54,29 @@ class LastValueOperatorTest extends WordSpec with Matchers {
       val inputFields = new LastValueOperator("lastValue", Map())
       inputFields.processReduce(Seq()) should be(Some(""))
 
-      val inputFields2 = new LastValueOperator("lastValue", Map("typeOp" -> "int"))
+      val inputFields2 = new LastValueOperator("lastValue", Map())
       inputFields2.processReduce(Seq(Some(1), Some(2))) should be(Some(2))
-
-      val inputFields4 = new LastValueOperator("lastValue", Map("typeOp" -> "string"))
-      inputFields4.processReduce(Seq(Some(1), Some(2))) should be(Some("2"))
 
       val inputFields3 = new LastValueOperator("lastValue", Map())
       inputFields3.processReduce(Seq(Some("a"), Some("b"))) should be(Some("b"))
+    }
+
+    "associative process must be " in {
+      val inputFields = new LastValueOperator("lastValue", Map())
+      val resultInput = Seq((Operator.OldValuesKey, Some(1L)),
+        (Operator.NewValuesKey, Some(1L)),
+        (Operator.NewValuesKey, None))
+      inputFields.associativity(resultInput) should be(Some("1"))
+
+      val inputFields2 = new LastValueOperator("lastValue", Map("typeOp" -> "int"))
+      val resultInput2 = Seq((Operator.OldValuesKey, Some(1L)),
+        (Operator.NewValuesKey, Some(1L)))
+      inputFields2.associativity(resultInput2) should be(Some(1))
+
+      val inputFields3 = new LastValueOperator("lastValue", Map("typeOp" -> null))
+      val resultInput3 = Seq((Operator.OldValuesKey, Some(1)),
+        (Operator.NewValuesKey, Some(2)))
+      inputFields3.associativity(resultInput3) should be(Some("2"))
     }
   }
 }

--- a/plugins/operator-max/src/main/scala/com/stratio/sparkta/plugin/operator/max/MaxOperator.scala
+++ b/plugins/operator-max/src/main/scala/com/stratio/sparkta/plugin/operator/max/MaxOperator.scala
@@ -17,13 +17,14 @@
 package com.stratio.sparkta.plugin.operator.max
 
 import java.io.{Serializable => JSerializable}
-import scala.util.Try
 
 import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk.{TypeOp, _}
 
+import scala.util.Try
+
 class MaxOperator(name: String, properties: Map[String, JSerializable]) extends Operator(name, properties)
-with ProcessMapAsNumber {
+with ProcessMapAsNumber with Associative {
 
   override val defaultTypeOperation = TypeOp.Double
 
@@ -32,9 +33,14 @@ with ProcessMapAsNumber {
   override val castingFilterType = TypeOp.Number
 
   override def processReduce(values: Iterable[Option[Any]]): Option[Double] = {
-    Try(Some(transformValueByTypeOp(
-      returnType,
-      getDistinctValues(values.flatten.map(_.asInstanceOf[Number].doubleValue())).max))
-    ).getOrElse(Some(OperatorConstants.Zero.toDouble))
+    Try(Option(getDistinctValues(values.flatten.map(_.asInstanceOf[Number].doubleValue())).max))
+      .getOrElse(Option(OperatorConstants.Zero.toDouble))
+  }
+
+  def associativity(values: Iterable[(String, Option[Any])]): Option[Double] = {
+    val newValues = extractValues(values, None)
+
+    Try(Option(transformValueByTypeOp(returnType, newValues.map(_.asInstanceOf[Number].doubleValue()).max)))
+      .getOrElse(Option(OperatorConstants.Zero.toDouble))
   }
 }

--- a/plugins/operator-max/src/test/scala/com/stratio/sparkta/plugin/operator/max/MaxOperatorTest.scala
+++ b/plugins/operator-max/src/test/scala/com/stratio/sparkta/plugin/operator/max/MaxOperatorTest.scala
@@ -16,6 +16,7 @@
 
 package com.stratio.sparkta.plugin.operator.max
 
+import com.stratio.sparkta.sdk.Operator
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{Matchers, WordSpec}
@@ -73,10 +74,6 @@ class MaxOperatorTest extends WordSpec with Matchers {
 
       val inputFields4 = new MaxOperator("max", Map())
       inputFields4.processReduce(Seq(None)) should be(Some(0d))
-
-      val inputFields5 = new MaxOperator("max", Map("typeOp" -> "string"))
-      inputFields5.processReduce(Seq(Some(1), Some(2))) should be(Some("2.0"))
-
     }
 
     "processReduce distinct must be " in {
@@ -92,9 +89,30 @@ class MaxOperatorTest extends WordSpec with Matchers {
       val inputFields4 = new MaxOperator("max", Map("distinct" -> "true"))
       inputFields4.processReduce(Seq(None)) should be(Some(0d))
 
-      val inputFields5 = new MaxOperator("max", Map("typeOp" -> "string", "distinct" -> "true"))
-      inputFields5.processReduce(Seq(Some(1), Some(2), Some(1))) should be(Some("2.0"))
-
     }
+
+    "associative process must be " in {
+      val inputFields = new MaxOperator("max", Map())
+      val resultInput = Seq((Operator.OldValuesKey, Some(1L)),
+        (Operator.NewValuesKey, Some(2L)),
+        (Operator.NewValuesKey, None))
+      inputFields.associativity(resultInput) should be(Some(2d))
+
+      val inputFields2 = new MaxOperator("max", Map("typeOp" -> "int"))
+      val resultInput2 = Seq((Operator.OldValuesKey, Some(1)),
+        (Operator.NewValuesKey, Some(3)))
+      inputFields2.associativity(resultInput2) should be(Some(3))
+
+      val inputFields3 = new MaxOperator("max", Map("typeOp" -> null))
+      val resultInput3 = Seq((Operator.OldValuesKey, Some(1)),
+        (Operator.NewValuesKey, Some(1)))
+      inputFields3.associativity(resultInput3) should be(Some(1d))
+
+      val inputFields4 = new MaxOperator("max", Map("typeOp" -> "string"))
+      val resultInput4 = Seq((Operator.OldValuesKey, Some(1)),
+        (Operator.NewValuesKey, Some(3)))
+      inputFields4.associativity(resultInput4) should be(Some("3.0"))
+    }
+
   }
 }

--- a/plugins/operator-median/src/test/scala/com/stratio/sparkta/plugin/operator/median/MedianOperatorTest.scala
+++ b/plugins/operator-median/src/test/scala/com/stratio/sparkta/plugin/operator/median/MedianOperatorTest.scala
@@ -56,8 +56,10 @@ class MedianOperatorTest extends WordSpec with Matchers {
       inputFields9.processMap(Map("field1" -> 1, "field2" -> 2)) should be(None)
 
       val inputFields10 = new MedianOperator("median",
-        Map("inputField" -> "field1", "filters" -> {"[{\"field\":\"field1\", \"type\": \"<\", \"value\":\"2\"}," +
-          "{\"field\":\"field2\", \"type\": \"<\", \"value\":\"2\"}]"}))
+        Map("inputField" -> "field1", "filters" -> {
+          "[{\"field\":\"field1\", \"type\": \"<\", \"value\":\"2\"}," +
+            "{\"field\":\"field2\", \"type\": \"<\", \"value\":\"2\"}]"
+        }))
       inputFields10.processMap(Map("field1" -> 1, "field2" -> 2)) should be(None)
     }
 
@@ -76,7 +78,6 @@ class MedianOperatorTest extends WordSpec with Matchers {
 
       val inputFields5 = new MedianOperator("median", Map("typeOp" -> "string"))
       inputFields5.processReduce(Seq(Some(1), Some(2), Some(3), Some(7), Some(7))) should be(Some("3.0"))
-
     }
 
     "processReduce distinct must be " in {
@@ -94,7 +95,6 @@ class MedianOperatorTest extends WordSpec with Matchers {
 
       val inputFields5 = new MedianOperator("median", Map("typeOp" -> "string", "distinct" -> "true"))
       inputFields5.processReduce(Seq(Some(1), Some(1), Some(2), Some(3), Some(7), Some(7))) should be(Some("2.5"))
-
     }
   }
 }

--- a/plugins/operator-min/src/main/scala/com/stratio/sparkta/plugin/operator/min/MinOperator.scala
+++ b/plugins/operator-min/src/main/scala/com/stratio/sparkta/plugin/operator/min/MinOperator.scala
@@ -17,13 +17,14 @@
 package com.stratio.sparkta.plugin.operator.min
 
 import java.io.{Serializable => JSerializable}
-import scala.util.Try
 
 import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk.{TypeOp, _}
 
+import scala.util.Try
+
 class MinOperator(name: String, properties: Map[String, JSerializable]) extends Operator(name, properties)
-with ProcessMapAsNumber {
+with ProcessMapAsNumber with Associative {
 
   override val defaultTypeOperation = TypeOp.Double
 
@@ -32,8 +33,14 @@ with ProcessMapAsNumber {
   override val castingFilterType = TypeOp.Number
 
   override def processReduce(values: Iterable[Option[Any]]): Option[Double] = {
-    Try(Some(transformValueByTypeOp(returnType,
-      getDistinctValues(values.flatten.map(_.asInstanceOf[Number].doubleValue())).min)))
+    Try(Option(getDistinctValues(values.flatten.map(_.asInstanceOf[Number].doubleValue())).min))
       .getOrElse(Some(OperatorConstants.Zero.toDouble))
+  }
+
+  def associativity(values: Iterable[(String, Option[Any])]): Option[Double] = {
+    val newValues = extractValues(values, None)
+
+    Try(Option(transformValueByTypeOp(returnType, newValues.map(_.asInstanceOf[Number].doubleValue()).min)))
+      .getOrElse(Option(OperatorConstants.Zero.toDouble))
   }
 }

--- a/plugins/operator-min/src/test/scala/com/stratio/sparkta/plugin/operator/min/MinOperatorTest.scala
+++ b/plugins/operator-min/src/test/scala/com/stratio/sparkta/plugin/operator/min/MinOperatorTest.scala
@@ -16,6 +16,7 @@
 
 package com.stratio.sparkta.plugin.operator.min
 
+import com.stratio.sparkta.sdk.Operator
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{Matchers, WordSpec}
@@ -74,10 +75,6 @@ class MinOperatorTest extends WordSpec with Matchers {
       val inputFields4 = new MinOperator("min", Map())
       inputFields4.processReduce(Seq(None)) should be(Some(0d))
 
-      val inputFields5 = new MinOperator("min", Map("typeOp" -> "string"))
-      inputFields5.processReduce(Seq(Some(1), Some(2), Some(3), Some(7), Some(7))) should be(Some("1.0"))
-
-
     }
 
     "processReduce disctinct must be " in {
@@ -93,10 +90,29 @@ class MinOperatorTest extends WordSpec with Matchers {
       val inputFields4 = new MinOperator("min", Map("distinct" -> "true"))
       inputFields4.processReduce(Seq(None)) should be(Some(0d))
 
-      val inputFields5 = new MinOperator("min", Map("typeOp" -> "string", "distinct" -> "true"))
-      inputFields5.processReduce(Seq(Some(1), Some(2), Some(3), Some(7), Some(7))) should be(Some("1.0"))
+    }
 
+    "associative process must be " in {
+      val inputFields = new MinOperator("max", Map())
+      val resultInput = Seq((Operator.OldValuesKey, Some(1L)),
+        (Operator.NewValuesKey, Some(2L)),
+        (Operator.NewValuesKey, None))
+      inputFields.associativity(resultInput) should be(Some(1d))
 
+      val inputFields2 = new MinOperator("max", Map("typeOp" -> "int"))
+      val resultInput2 = Seq((Operator.OldValuesKey, Some(1)),
+        (Operator.NewValuesKey, Some(2)))
+      inputFields2.associativity(resultInput2) should be(Some(1))
+
+      val inputFields3 = new MinOperator("max", Map("typeOp" -> null))
+      val resultInput3 = Seq((Operator.OldValuesKey, Some(1)),
+        (Operator.NewValuesKey, Some(1)))
+      inputFields3.associativity(resultInput3) should be(Some(1d))
+
+      val inputFields4 = new MinOperator("max", Map("typeOp" -> "string"))
+      val resultInput4 = Seq((Operator.OldValuesKey, Some(1)),
+        (Operator.NewValuesKey, Some(3)))
+      inputFields4.associativity(resultInput4) should be(Some("1.0"))
     }
   }
 }

--- a/plugins/operator-range/src/main/scala/com/stratio/sparkta/plugin/operator/range/RangeOperator.scala
+++ b/plugins/operator-range/src/main/scala/com/stratio/sparkta/plugin/operator/range/RangeOperator.scala
@@ -21,10 +21,8 @@ import java.io.{Serializable => JSerializable}
 import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk.{TypeOp, _}
 
-import scala.util.Try
-
 class RangeOperator(name: String, properties: Map[String, JSerializable]) extends Operator(name, properties)
-with ProcessMapAsNumber with Associative{
+with ProcessMapAsNumber {
 
   override val defaultTypeOperation = TypeOp.Double
 
@@ -32,26 +30,13 @@ with ProcessMapAsNumber with Associative{
 
   override val castingFilterType = TypeOp.Number
 
-  override def processReduce(values: Iterable[Option[Any]]): Option[(Double, Double)] = {
+  override def processReduce(values: Iterable[Option[Any]]): Option[Double] = {
     val valuesFiltered = getDistinctValues(values.flatten)
     valuesFiltered.size match {
-      case (nz) if nz != 0 => {
+      case (nz) if nz != 0 =>
         val valuesConverted = valuesFiltered.map(_.asInstanceOf[Number].doubleValue())
-        Option((valuesConverted.max, valuesConverted.min))
-      }
-      case _ => Option((OperatorConstants.Zero.toDouble, OperatorConstants.Zero.toDouble))
+        Some(transformValueByTypeOp(returnType, valuesConverted.max - valuesConverted.min))
+      case _ => Some(OperatorConstants.Zero.toDouble)
     }
-  }
-
-  def associativity(values: Iterable[(String, Option[Any])]): Option[Double] = {
-    val newValues = extractValues(values, None).map(value => {
-      val numberValue = value.asInstanceOf[(Number, Number)]
-      (numberValue._1.doubleValue(), numberValue._2.doubleValue())
-    })
-    val maxValue = newValues.map{ case (max, min) => max}.max
-    val minValue = newValues.map{ case (max, min) => min}.min
-
-    Try(Option(transformValueByTypeOp(returnType, maxValue - minValue)))
-      .getOrElse(Option(OperatorConstants.Zero.toDouble))
   }
 }

--- a/plugins/operator-range/src/test/scala/com/stratio/sparkta/plugin/operator/avg/RangeOperatorTest.scala
+++ b/plugins/operator-range/src/test/scala/com/stratio/sparkta/plugin/operator/avg/RangeOperatorTest.scala
@@ -56,39 +56,43 @@ class RangeOperatorTest extends WordSpec with Matchers {
       inputFields9.processMap(Map("field1" -> 1, "field2" -> 2)) should be(None)
 
       val inputFields10 = new RangeOperator("range",
-        Map("inputField" -> "field1", "filters" -> {
-          "[{\"field\":\"field1\", \"type\": \"<\", \"value\":\"2\"}," +
-            "{\"field\":\"field2\", \"type\": \"<\", \"value\":\"2\"}]"
-        }))
+        Map("inputField" -> "field1", "filters" -> {"[{\"field\":\"field1\", \"type\": \"<\", \"value\":\"2\"}," +
+          "{\"field\":\"field2\", \"type\": \"<\", \"value\":\"2\"}]"}))
       inputFields10.processMap(Map("field1" -> 1, "field2" -> 2)) should be(None)
     }
 
     "processReduce must be " in {
       val inputFields = new RangeOperator("range", Map())
-      inputFields.processReduce(Seq()) should be(Some((0d, 0d)))
+      inputFields.processReduce(Seq()) should be(Some(0d))
 
       val inputFields2 = new RangeOperator("range", Map())
-      inputFields2.processReduce(Seq(Some(1), Some(1))) should be(Some((1d, 1d)))
+      inputFields2.processReduce(Seq(Some(1), Some(1))) should be(Some(0))
 
       val inputFields3 = new RangeOperator("range", Map())
-      inputFields3.processReduce(Seq(Some(1), Some(2), Some(4))) should be((Some(4d, 1d)))
+      inputFields3.processReduce(Seq(Some(1), Some(2), Some(4))) should be(Some(3))
 
       val inputFields4 = new RangeOperator("range", Map())
-      inputFields4.processReduce(Seq(None)) should be(Some((0d, 0d)))
+      inputFields4.processReduce(Seq(None)) should be(Some(0d))
+
+      val inputFields5 = new RangeOperator("range", Map("typeOp" -> "string"))
+      inputFields5.processReduce(Seq(Some(1), Some(2), Some(3), Some(7), Some(7))) should be(Some("6.0"))
     }
 
     "processReduce distinct must be " in {
       val inputFields = new RangeOperator("range", Map("distinct" -> "true"))
-      inputFields.processReduce(Seq()) should be(Some((0d, 0d)))
+      inputFields.processReduce(Seq()) should be(Some(0d))
 
       val inputFields2 = new RangeOperator("range", Map("distinct" -> "true"))
-      inputFields2.processReduce(Seq(Some(1), Some(1))) should be(Some((1d, 1d)))
+      inputFields2.processReduce(Seq(Some(1), Some(1))) should be(Some(0))
 
       val inputFields3 = new RangeOperator("range", Map("distinct" -> "true"))
-      inputFields3.processReduce(Seq(Some(1), Some(2), Some(4))) should be(Some((4d, 1d)))
+      inputFields3.processReduce(Seq(Some(1), Some(2), Some(4))) should be(Some(3))
 
       val inputFields4 = new RangeOperator("range", Map("distinct" -> "true"))
-      inputFields4.processReduce(Seq(None)) should be(Some((0d, 0d)))
+      inputFields4.processReduce(Seq(None)) should be(Some(0d))
+
+      val inputFields5 = new RangeOperator("range", Map("typeOp" -> "string", "distinct" -> "true"))
+      inputFields5.processReduce(Seq(Some(1), Some(2), Some(3), Some(7), Some(7))) should be(Some("6.0"))
     }
   }
 }

--- a/plugins/operator-range/src/test/scala/com/stratio/sparkta/plugin/operator/avg/RangeOperatorTest.scala
+++ b/plugins/operator-range/src/test/scala/com/stratio/sparkta/plugin/operator/avg/RangeOperatorTest.scala
@@ -16,6 +16,7 @@
 
 package com.stratio.sparkta.plugin.operator.range
 
+import com.stratio.sparkta.sdk.Operator
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{Matchers, WordSpec}
@@ -65,36 +66,51 @@ class RangeOperatorTest extends WordSpec with Matchers {
 
     "processReduce must be " in {
       val inputFields = new RangeOperator("range", Map())
-      inputFields.processReduce(Seq()) should be(Some(0d))
+      inputFields.processReduce(Seq()) should be(Some((0d, 0d)))
 
       val inputFields2 = new RangeOperator("range", Map())
-      inputFields2.processReduce(Seq(Some(1), Some(1))) should be(Some(0))
+      inputFields2.processReduce(Seq(Some(1), Some(1))) should be(Some((1d, 1d)))
 
       val inputFields3 = new RangeOperator("range", Map())
-      inputFields3.processReduce(Seq(Some(1), Some(2), Some(4))) should be(Some(3))
+      inputFields3.processReduce(Seq(Some(1), Some(2), Some(4))) should be((Some(4d, 1d)))
 
       val inputFields4 = new RangeOperator("range", Map())
-      inputFields4.processReduce(Seq(None)) should be(Some(0d))
+      inputFields4.processReduce(Seq(None)) should be(Some((0d, 0d)))
 
-      val inputFields5 = new RangeOperator("range", Map("typeOp" -> "string"))
-      inputFields5.processReduce(Seq(Some(1), Some(2), Some(3), Some(7), Some(7))) should be(Some("6.0"))
     }
 
     "processReduce distinct must be " in {
       val inputFields = new RangeOperator("range", Map("distinct" -> "true"))
-      inputFields.processReduce(Seq()) should be(Some(0d))
+      inputFields.processReduce(Seq()) should be(Some((0d, 0d)))
 
       val inputFields2 = new RangeOperator("range", Map("distinct" -> "true"))
-      inputFields2.processReduce(Seq(Some(1), Some(1))) should be(Some(0))
+      inputFields2.processReduce(Seq(Some(1), Some(1))) should be(Some((1d, 1d)))
 
       val inputFields3 = new RangeOperator("range", Map("distinct" -> "true"))
-      inputFields3.processReduce(Seq(Some(1), Some(2), Some(4))) should be(Some(3))
+      inputFields3.processReduce(Seq(Some(1), Some(2), Some(4))) should be(Some((4d, 1d)))
 
       val inputFields4 = new RangeOperator("range", Map("distinct" -> "true"))
-      inputFields4.processReduce(Seq(None)) should be(Some(0d))
+      inputFields4.processReduce(Seq(None)) should be(Some((0d, 0d)))
 
-      val inputFields5 = new RangeOperator("range", Map("typeOp" -> "string", "distinct" -> "true"))
-      inputFields5.processReduce(Seq(Some(1), Some(2), Some(3), Some(7), Some(7))) should be(Some("6.0"))
+    }
+
+    "associative process must be " in {
+      val inputFields = new RangeOperator("range", Map())
+      val resultInput = Seq((Operator.OldValuesKey, Some((1d, 1d))),
+        (Operator.NewValuesKey, Some((2d, 1d))),
+        (Operator.NewValuesKey, None))
+      inputFields.associativity(resultInput) should be(Some(1d))
+
+      val inputFields2 = new RangeOperator("range", Map())
+      val resultInput2 = Seq((Operator.OldValuesKey, Some((10d, 2d))),
+        (Operator.NewValuesKey, Some((6d, 1d))))
+      inputFields2.associativity(resultInput2) should be(Some(9d))
+
+      val inputFields3 = new RangeOperator("range", Map())
+      val resultInput3 = Seq((Operator.OldValuesKey, Some((5d, 1d))),
+        (Operator.NewValuesKey, Some((10d, 5d))))
+      inputFields3.associativity(resultInput3) should be(Some(9d))
+
     }
   }
 }

--- a/plugins/operator-range/src/test/scala/com/stratio/sparkta/plugin/operator/avg/RangeOperatorTest.scala
+++ b/plugins/operator-range/src/test/scala/com/stratio/sparkta/plugin/operator/avg/RangeOperatorTest.scala
@@ -16,7 +16,6 @@
 
 package com.stratio.sparkta.plugin.operator.range
 
-import com.stratio.sparkta.sdk.Operator
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{Matchers, WordSpec}
@@ -76,7 +75,6 @@ class RangeOperatorTest extends WordSpec with Matchers {
 
       val inputFields4 = new RangeOperator("range", Map())
       inputFields4.processReduce(Seq(None)) should be(Some((0d, 0d)))
-
     }
 
     "processReduce distinct must be " in {
@@ -91,26 +89,6 @@ class RangeOperatorTest extends WordSpec with Matchers {
 
       val inputFields4 = new RangeOperator("range", Map("distinct" -> "true"))
       inputFields4.processReduce(Seq(None)) should be(Some((0d, 0d)))
-
-    }
-
-    "associative process must be " in {
-      val inputFields = new RangeOperator("range", Map())
-      val resultInput = Seq((Operator.OldValuesKey, Some((1d, 1d))),
-        (Operator.NewValuesKey, Some((2d, 1d))),
-        (Operator.NewValuesKey, None))
-      inputFields.associativity(resultInput) should be(Some(1d))
-
-      val inputFields2 = new RangeOperator("range", Map())
-      val resultInput2 = Seq((Operator.OldValuesKey, Some((10d, 2d))),
-        (Operator.NewValuesKey, Some((6d, 1d))))
-      inputFields2.associativity(resultInput2) should be(Some(9d))
-
-      val inputFields3 = new RangeOperator("range", Map())
-      val resultInput3 = Seq((Operator.OldValuesKey, Some((5d, 1d))),
-        (Operator.NewValuesKey, Some((10d, 5d))))
-      inputFields3.associativity(resultInput3) should be(Some(9d))
-
     }
   }
 }

--- a/plugins/operator-range/src/test/scala/com/stratio/sparkta/plugin/operator/avg/RangeOperatorTest.scala
+++ b/plugins/operator-range/src/test/scala/com/stratio/sparkta/plugin/operator/avg/RangeOperatorTest.scala
@@ -56,8 +56,10 @@ class RangeOperatorTest extends WordSpec with Matchers {
       inputFields9.processMap(Map("field1" -> 1, "field2" -> 2)) should be(None)
 
       val inputFields10 = new RangeOperator("range",
-        Map("inputField" -> "field1", "filters" -> {"[{\"field\":\"field1\", \"type\": \"<\", \"value\":\"2\"}," +
-          "{\"field\":\"field2\", \"type\": \"<\", \"value\":\"2\"}]"}))
+        Map("inputField" -> "field1", "filters" -> {
+          "[{\"field\":\"field1\", \"type\": \"<\", \"value\":\"2\"}," +
+            "{\"field\":\"field2\", \"type\": \"<\", \"value\":\"2\"}]"
+        }))
       inputFields10.processMap(Map("field1" -> 1, "field2" -> 2)) should be(None)
     }
 

--- a/plugins/operator-stddev/src/test/scala/com/stratio/sparkta/plugin/operator/stddev/StddevOperatorTest.scala
+++ b/plugins/operator-stddev/src/test/scala/com/stratio/sparkta/plugin/operator/stddev/StddevOperatorTest.scala
@@ -56,8 +56,10 @@ class StddevOperatorTest extends WordSpec with Matchers {
       inputFields9.processMap(Map("field1" -> 1, "field2" -> 2)) should be(None)
 
       val inputFields10 = new StddevOperator("stdev",
-        Map("inputField" -> "field1", "filters" -> {"[{\"field\":\"field1\", \"type\": \"<\", \"value\":\"2\"}," +
-          "{\"field\":\"field2\", \"type\": \"<\", \"value\":\"2\"}]"}))
+        Map("inputField" -> "field1", "filters" -> {
+          "[{\"field\":\"field1\", \"type\": \"<\", \"value\":\"2\"}," +
+            "{\"field\":\"field2\", \"type\": \"<\", \"value\":\"2\"}]"
+        }))
       inputFields10.processMap(Map("field1" -> 1, "field2" -> 2)) should be(None)
     }
 
@@ -79,7 +81,6 @@ class StddevOperatorTest extends WordSpec with Matchers {
       val inputFields5 = new StddevOperator("stdev", Map("typeOp" -> "string"))
       inputFields5.processReduce(
         Seq(Some(1), Some(2), Some(3), Some(6.5), Some(7.5))) should be(Some("2.850438562747845"))
-
     }
 
     "processReduce distinct must be " in {
@@ -100,7 +101,6 @@ class StddevOperatorTest extends WordSpec with Matchers {
       val inputFields5 = new StddevOperator("stdev", Map("typeOp" -> "string", "distinct" -> "true"))
       inputFields5.processReduce(
         Seq(Some(1), Some(1), Some(2), Some(3), Some(6.5), Some(7.5))) should be(Some("2.850438562747845"))
-
     }
   }
 }

--- a/plugins/operator-sum/src/main/scala/com/stratio/sparkta/plugin/operator/sum/SumOperator.scala
+++ b/plugins/operator-sum/src/main/scala/com/stratio/sparkta/plugin/operator/sum/SumOperator.scala
@@ -23,25 +23,24 @@ import com.stratio.sparkta.sdk._
 
 import scala.util.Try
 
-class SumOperator(name : String, properties : Map[String, JSerializable]) extends Operator(name, properties)
-with ProcessMapAsNumber {
+class SumOperator(name: String, properties: Map[String, JSerializable]) extends Operator(name, properties)
+with ProcessMapAsNumber with Associative {
 
   override val defaultTypeOperation = TypeOp.Double
 
   override val writeOperation = WriteOp.Inc
 
-  override val associativity = MathProperties.Associative
-
   override val castingFilterType = TypeOp.Number
 
-  override def processReduce(values : Iterable[Option[Any]]) : Option[Double] = {
-    Try(
-      Some(
-        getDistinctValues(values.flatten.map(_.asInstanceOf[Number].doubleValue())).sum)
-    ).getOrElse(Some(OperatorConstants.Zero.toDouble))
+  override def processReduce(values: Iterable[Option[Any]]): Option[Double] = {
+    Try(Option(getDistinctValues(values.flatten.map(_.asInstanceOf[Number].doubleValue())).sum))
+      .getOrElse(Some(OperatorConstants.Zero.toDouble))
   }
 
-  override def processAssociative(values : Iterable[Option[Any]]) : Option[Double] = {
-    Some(transformValueByTypeOp(returnType, values.flatten.map(_.asInstanceOf[Number].doubleValue()).sum))
+  def associativity(values: Iterable[(String, Option[Any])]): Option[Double] = {
+    val newValues = extractValues(values, None)
+
+    Try(Option(transformValueByTypeOp(returnType, newValues.map(_.asInstanceOf[Number].doubleValue()).sum)))
+      .getOrElse(Some(OperatorConstants.Zero.toDouble))
   }
 }

--- a/plugins/operator-sum/src/main/scala/com/stratio/sparkta/plugin/operator/sum/SumOperator.scala
+++ b/plugins/operator-sum/src/main/scala/com/stratio/sparkta/plugin/operator/sum/SumOperator.scala
@@ -17,26 +17,31 @@
 package com.stratio.sparkta.plugin.operator.sum
 
 import java.io.{Serializable => JSerializable}
-import scala.util.Try
 
 import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk._
 
-class SumOperator(name: String, properties: Map[String, JSerializable]) extends Operator(name, properties)
+import scala.util.Try
+
+class SumOperator(name : String, properties : Map[String, JSerializable]) extends Operator(name, properties)
 with ProcessMapAsNumber {
 
   override val defaultTypeOperation = TypeOp.Double
 
   override val writeOperation = WriteOp.Inc
 
+  override val associativity = MathProperties.Associative
+
   override val castingFilterType = TypeOp.Number
 
-  override def processReduce(values: Iterable[Option[Any]]): Option[Double] = {
+  override def processReduce(values : Iterable[Option[Any]]) : Option[Double] = {
     Try(
-      Some(transformValueByTypeOp(
-        returnType,
-        getDistinctValues(values.flatten.map(_.asInstanceOf[Number].doubleValue())).sum))
+      Some(
+        getDistinctValues(values.flatten.map(_.asInstanceOf[Number].doubleValue())).sum)
     ).getOrElse(Some(OperatorConstants.Zero.toDouble))
   }
-}
 
+  override def processAssociative(values : Iterable[Option[Any]]) : Option[Double] = {
+    Some(transformValueByTypeOp(returnType, values.flatten.map(_.asInstanceOf[Number].doubleValue()).sum))
+  }
+}

--- a/plugins/operator-sum/src/test/scala/com/stratio/sparkta/plugin/operator/sum/SumOperatorTest.scala
+++ b/plugins/operator-sum/src/test/scala/com/stratio/sparkta/plugin/operator/sum/SumOperatorTest.scala
@@ -16,6 +16,7 @@
 
 package com.stratio.sparkta.plugin.operator.sum
 
+import com.stratio.sparkta.sdk.Operator
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{Matchers, WordSpec}
@@ -87,10 +88,16 @@ class SumOperatorTest extends WordSpec with Matchers {
 
     "associative process must be " in {
       val inputFields = new SumOperator("count", Map())
-      inputFields.processAssociative(Seq(Some(1L), Some(1L), None)) should be(Some(2d))
+      val resultInput = Seq((Operator.OldValuesKey, Some(1L)),
+        (Operator.NewValuesKey, Some(1L)),
+        (Operator.NewValuesKey, None))
+      inputFields.associativity(resultInput) should be(Some(2d))
 
       val inputFields2 = new SumOperator("count", Map("typeOp" -> "string"))
-      inputFields2.processAssociative(Seq(Some(1), Some(1))) should be(Some("2.0"))
+      val resultInput2 = Seq((Operator.OldValuesKey, Some(1L)),
+        (Operator.NewValuesKey, Some(1L)),
+        (Operator.NewValuesKey, None))
+      inputFields2.associativity(resultInput2) should be(Some("2.0"))
     }
   }
 }

--- a/plugins/operator-sum/src/test/scala/com/stratio/sparkta/plugin/operator/sum/SumOperatorTest.scala
+++ b/plugins/operator-sum/src/test/scala/com/stratio/sparkta/plugin/operator/sum/SumOperatorTest.scala
@@ -56,10 +56,11 @@ class SumOperatorTest extends WordSpec with Matchers {
       inputFields9.processMap(Map("field1" -> 1, "field2" -> 2)) should be(None)
 
       val inputFields10 = new SumOperator("sum",
-        Map("inputField" -> "field1", "filters" -> {"[{\"field\":\"field1\", \"type\": \"<\", \"value\":\"2\"}," +
-          "{\"field\":\"field2\", \"type\": \"<\", \"value\":\"2\"}]"}))
+        Map("inputField" -> "field1", "filters" -> {
+          "[{\"field\":\"field1\", \"type\": \"<\", \"value\":\"2\"}," +
+            "{\"field\":\"field2\", \"type\": \"<\", \"value\":\"2\"}]"
+        }))
       inputFields10.processMap(Map("field1" -> 1, "field2" -> 2)) should be(None)
-
     }
 
     "processReduce must be " in {
@@ -67,19 +68,13 @@ class SumOperatorTest extends WordSpec with Matchers {
       inputFields.processReduce(Seq()) should be(Some(0d))
 
       val inputFields2 = new SumOperator("sum", Map())
-      inputFields2.processReduce(Seq(Some(1), Some(2), Some(3), Some(7), Some(7))) should be (Some(20d))
+      inputFields2.processReduce(Seq(Some(1), Some(2), Some(3), Some(7), Some(7))) should be(Some(20d))
 
       val inputFields3 = new SumOperator("sum", Map())
-      inputFields3.processReduce(Seq(Some(1), Some(2), Some(3), Some(6.5), Some(7.5))) should be (Some(20d))
+      inputFields3.processReduce(Seq(Some(1), Some(2), Some(3), Some(6.5), Some(7.5))) should be(Some(20d))
 
       val inputFields4 = new SumOperator("sum", Map())
       inputFields4.processReduce(Seq(None)) should be(Some(0d))
-
-      val inputFields5 = new SumOperator("sum", Map("typeOp" -> "string"))
-      inputFields5.processReduce(Seq(Some(1), Some(2), Some(3))) should be(Some("6.0"))
-
-      val inputFields6 = new SumOperator("sum", Map("typeOp" -> "string"))
-      inputFields6.processReduce(Seq(Some("1"), Some(2), Some(3))) should be(Some(0.0))
     }
 
     "processReduce distinct must be " in {
@@ -87,8 +82,15 @@ class SumOperatorTest extends WordSpec with Matchers {
       inputFields.processReduce(Seq()) should be(Some(0d))
 
       val inputFields2 = new SumOperator("sum", Map("distinct" -> "true"))
-      inputFields2.processReduce(Seq(Some(1), Some(2), Some(1))) should be (Some(3d))
+      inputFields2.processReduce(Seq(Some(1), Some(2), Some(1))) should be(Some(3d))
+    }
 
+    "associative process must be " in {
+      val inputFields = new SumOperator("count", Map())
+      inputFields.processAssociative(Seq(Some(1L), Some(1L), None)) should be(Some(2d))
+
+      val inputFields2 = new SumOperator("count", Map("typeOp" -> "string"))
+      inputFields2.processAssociative(Seq(Some(1), Some(1))) should be(Some("2.0"))
     }
   }
 }

--- a/plugins/operator-totalEntityCount/src/test/scala/com/stratio/sparkta/plugin/operator/totalEntityCount/TotalEntityCountOperatorTest.scala
+++ b/plugins/operator-totalEntityCount/src/test/scala/com/stratio/sparkta/plugin/operator/totalEntityCount/TotalEntityCountOperatorTest.scala
@@ -16,6 +16,7 @@
 
 package com.stratio.sparkta.plugin.operator.totalEntityCount
 
+import com.stratio.sparkta.sdk.Operator
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{Matchers, WordSpec}
@@ -26,55 +27,70 @@ class TotalEntityCountOperatorTest extends WordSpec with Matchers {
   "Entity Count Operator" should {
 
     "processMap must be " in {
-      val inputField = new TotalEntityCountOperator("entityCount", Map())
+      val inputField = new TotalEntityCountOperator("totalEntityCount", Map())
       inputField.processMap(Map("field1" -> 1, "field2" -> 2)) should be(None)
 
-      val inputFields2 = new TotalEntityCountOperator("entityCount", Map("inputField" -> "field1"))
+      val inputFields2 = new TotalEntityCountOperator("totalEntityCount", Map("inputField" -> "field1"))
       inputFields2.processMap(Map("field3" -> 1, "field2" -> 2)) should be(None)
 
-      val inputFields3 = new TotalEntityCountOperator("entityCount", Map("inputField" -> "field1"))
+      val inputFields3 = new TotalEntityCountOperator("totalEntityCount", Map("inputField" -> "field1"))
       inputFields3.processMap(Map("field1" -> "hola holo", "field2" -> 2)) should be(Some(Seq("hola holo")))
 
-      val inputFields4 = new TotalEntityCountOperator("entityCount", Map("inputField" -> "field1", "split" -> ","))
+      val inputFields4 = new TotalEntityCountOperator("totalEntityCount", Map("inputField" -> "field1", "split" -> ","))
       inputFields4.processMap(Map("field1" -> "hola holo", "field2" -> 2)) should be(Some(Seq("hola holo")))
 
-      val inputFields5 = new TotalEntityCountOperator("entityCount", Map("inputField" -> "field1", "split" -> "-"))
+      val inputFields5 = new TotalEntityCountOperator("totalEntityCount", Map("inputField" -> "field1", "split" -> "-"))
       inputFields5.processMap(Map("field1" -> "hola-holo", "field2" -> 2)) should be(Some(Seq("hola", "holo")))
 
-      val inputFields6 = new TotalEntityCountOperator("entityCount", Map("inputField" -> "field1", "split" -> ","))
+      val inputFields6 = new TotalEntityCountOperator("totalEntityCount", Map("inputField" -> "field1", "split" -> ","))
       inputFields6.processMap(Map("field1" -> "hola,holo adios", "field2" -> 2)) should be(
         Some(Seq("hola", "holo " + "adios")))
 
-      val inputFields7 = new TotalEntityCountOperator("entityCount",
+      val inputFields7 = new TotalEntityCountOperator("totalEntityCount",
         Map("inputField" -> "field1", "filters" -> "[{\"field\":\"field1\", \"type\": \"!=\", \"value\":\"hola\"}]"))
       inputFields7.processMap(Map("field1" -> "hola", "field2" -> 2)) should be(None)
 
-      val inputFields8 = new TotalEntityCountOperator("entityCount",
+      val inputFields8 = new TotalEntityCountOperator("totalEntityCount",
         Map("inputField" -> "field1", "filters" -> "[{\"field\":\"field1\", \"type\": \"!=\", \"value\":\"hola\"}]",
           "split" -> " "))
       inputFields8.processMap(Map("field1" -> "hola holo", "field2" -> 2)) should be(Some(Seq("hola", "holo")))
     }
 
     "processReduce must be " in {
-      val inputFields = new TotalEntityCountOperator("entityCount", Map())
+      val inputFields = new TotalEntityCountOperator("totalEntityCount", Map())
       inputFields.processReduce(Seq()) should be(Some(0L))
 
-      val inputFields2 = new TotalEntityCountOperator("entityCount", Map())
+      val inputFields2 = new TotalEntityCountOperator("totalEntityCount", Map())
       inputFields2.processReduce(Seq(Some(Seq("hola", "holo")))) should be(Some(2L))
 
-      val inputFields3 = new TotalEntityCountOperator("entityCount", Map())
+      val inputFields3 = new TotalEntityCountOperator("totalEntityCount", Map())
       inputFields3.processReduce(Seq(Some(Seq("hola", "holo", "hola")))) should be(Some(3L))
 
-      val inputFields4 = new TotalEntityCountOperator("entityCount", Map())
+      val inputFields4 = new TotalEntityCountOperator("totalEntityCount", Map())
       inputFields4.processReduce(Seq(Some(""))) should be(Some(0L))
     }
 
     "processReduce distinct must be " in {
-      val inputFields = new TotalEntityCountOperator("entityCount", Map("distinct" -> "true"))
+      val inputFields = new TotalEntityCountOperator("totalEntityCount", Map("distinct" -> "true"))
       inputFields.processReduce(Seq()) should be(Some(0L))
 
-      val inputFields2 = new TotalEntityCountOperator("entityCount", Map("distinct" -> "true"))
+      val inputFields2 = new TotalEntityCountOperator("totalEntityCount", Map("distinct" -> "true"))
       inputFields2.processReduce(Seq(Some(Seq("hola", "holo", "hola")))) should be(Some(2L))
+    }
+
+    "associative process must be " in {
+      val inputFields = new TotalEntityCountOperator("totalEntityCount", Map())
+      val resultInput = Seq((Operator.OldValuesKey, Some(2)), (Operator.NewValuesKey, None))
+      inputFields.associativity(resultInput) should be(Some(2))
+
+      val inputFields2 = new TotalEntityCountOperator("totalEntityCount", Map("typeOp" -> "int"))
+      val resultInput2 = Seq((Operator.OldValuesKey, Some(2)),
+        (Operator.NewValuesKey, Some(1)))
+      inputFields2.associativity(resultInput2) should be(Some(3))
+
+      val inputFields3 = new TotalEntityCountOperator("totalEntityCount", Map("typeOp" -> null))
+      val resultInput3 = Seq((Operator.OldValuesKey, Some(2)))
+      inputFields3.associativity(resultInput3) should be(Some(2))
     }
   }
 }

--- a/plugins/operator-variance/src/test/scala/com/stratio/sparkta/plugin/operator/variance/VarianceOperatorTest.scala
+++ b/plugins/operator-variance/src/test/scala/com/stratio/sparkta/plugin/operator/variance/VarianceOperatorTest.scala
@@ -56,8 +56,10 @@ class VarianceOperatorTest extends WordSpec with Matchers {
       inputFields9.processMap(Map("field1" -> 1, "field2" -> 2)) should be(None)
 
       val inputFields10 = new VarianceOperator("variance",
-        Map("inputField" -> "field1", "filters" -> {"[{\"field\":\"field1\", \"type\": \"<\", \"value\":\"2\"}," +
-          "{\"field\":\"field2\", \"type\": \"<\", \"value\":\"2\"}]"}))
+        Map("inputField" -> "field1", "filters" -> {
+          "[{\"field\":\"field1\", \"type\": \"<\", \"value\":\"2\"}," +
+            "{\"field\":\"field2\", \"type\": \"<\", \"value\":\"2\"}]"
+        }))
       inputFields10.processMap(Map("field1" -> 1, "field2" -> 2)) should be(None)
     }
 
@@ -76,7 +78,6 @@ class VarianceOperatorTest extends WordSpec with Matchers {
 
       val inputFields5 = new VarianceOperator("variance", Map("typeOp" -> "string"))
       inputFields5.processReduce(Seq(Some(1), Some(2), Some(3), Some(7), Some(7))) should be(Some("8.0"))
-
     }
 
     "processReduce distinct must be " in {
@@ -94,7 +95,6 @@ class VarianceOperatorTest extends WordSpec with Matchers {
 
       val inputFields5 = new VarianceOperator("variance", Map("typeOp" -> "string", "distinct" -> "true"))
       inputFields5.processReduce(Seq(Some(1), Some(2), Some(3), Some(7), Some(7))) should be(Some("6.916666666666667"))
-
     }
   }
 }

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/Associative.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/Associative.scala
@@ -18,5 +18,6 @@ package com.stratio.sparkta.sdk
 
 trait Associative {
 
+    self: Operator =>
     def associativity(values: Iterable[(String, Option[Any])]): Option[Any]
 }

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/Associative.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/Associative.scala
@@ -18,6 +18,5 @@ package com.stratio.sparkta.sdk
 
 trait Associative {
 
-  self: Operator =>
     def associativity(values: Iterable[(String, Option[Any])]): Option[Any]
 }

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/Associative.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/Associative.scala
@@ -1,4 +1,3 @@
-
 /**
  * Copyright (C) 2015 Stratio (http://stratio.com)
  *
@@ -17,8 +16,8 @@
 
 package com.stratio.sparkta.sdk
 
-object MathProperties extends Enumeration {
+trait Associative {
 
-  type Associativity = Value
-  val Associative, NonAssociative = Value
+  self: Operator =>
+    def associativity(values: Iterable[(String, Option[Any])]): Option[Any]
 }

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/EntityCount.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/EntityCount.scala
@@ -18,7 +18,6 @@ package com.stratio.sparkta.sdk
 
 import java.io.{Serializable => JSerializable}
 
-import com.stratio.sparkta.sdk.TypeOp.TypeOp
 import com.stratio.sparkta.sdk.ValidatingPropertyMap._
 
 abstract class EntityCount(name: String, properties: Map[String, JSerializable]) extends Operator(name, properties) {
@@ -31,13 +30,13 @@ abstract class EntityCount(name: String, properties: Map[String, JSerializable])
   override def processMap(inputFields: Map[String, JSerializable]): Option[Seq[String]] = {
     if (inputField.isDefined && inputFields.contains(inputField.get))
       applyFilters(inputFields)
-        .flatMap(filteredFields => filteredFields.get(inputField.get).map(applySplitters(_)))
+        .flatMap(filteredFields => filteredFields.get(inputField.get).map(applySplitters))
     else None
   }
 
   private def applySplitters(value: JSerializable): Seq[String] = {
     val replacedValue = applyReplaceRegex(value.toString)
-    if (!split.isEmpty) replacedValue.split(split.get) else Seq(replacedValue)
+    if (split.isDefined) replacedValue.split(split.get) else Seq(replacedValue)
   }
 
   private def applyReplaceRegex(value: String): String =

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/MathProperties.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/MathProperties.scala
@@ -1,0 +1,24 @@
+
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparkta.sdk
+
+object MathProperties extends Enumeration {
+
+  type Associativity = Value
+  val Associative, NonAssociative = Value
+}

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/Operator.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/Operator.scala
@@ -17,17 +17,18 @@
 package com.stratio.sparkta.sdk
 
 import java.io.{Serializable => JSerializable}
+
+import com.stratio.sparkta.sdk.MathProperties.Associativity
+import com.stratio.sparkta.sdk.TypeOp.TypeOp
+import com.stratio.sparkta.sdk.ValidatingPropertyMap._
+import com.stratio.sparkta.sdk.WriteOp.WriteOp
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+
 import scala.collection.immutable.StringOps
 import scala.language.reflectiveCalls
 import scala.runtime.RichDouble
 import scala.util._
-
-import org.json4s._
-import org.json4s.jackson.JsonMethods._
-
-import com.stratio.sparkta.sdk.TypeOp.TypeOp
-import com.stratio.sparkta.sdk.ValidatingPropertyMap._
-import com.stratio.sparkta.sdk.WriteOp.WriteOp
 
 abstract class Operator(name: String, properties: Map[String, JSerializable]) extends Parameterizable(properties)
 with Ordered[Operator] with TypeConversions {
@@ -41,6 +42,8 @@ with Ordered[Operator] with TypeConversions {
 
   def key: String = name
 
+  def associativity: Associativity = MathProperties.NonAssociative
+
   def distinct: Boolean = Try(properties.getString("distinct").toBoolean).getOrElse(false)
 
   def writeOperation: WriteOp
@@ -48,6 +51,8 @@ with Ordered[Operator] with TypeConversions {
   val inputField = properties.getString("inputField", None)
 
   def processReduce(values: Iterable[Option[Any]]): Option[Any]
+
+  def processAssociative(values: Iterable[Option[Any]]): Option[Any] = None
 
   def castingFilterType: TypeOp = TypeOp.String
 

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/TypeConversions.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/TypeConversions.scala
@@ -39,9 +39,7 @@ trait TypeConversions {
 
   def getResultType(typeOperation: String): Option[TypeOp] =
     if (!typeOperation.isEmpty) {
-      operationProps.get(typeOperation) match {
-        case Some(operation) => Some(getTypeOperationByName(operation.toString, defaultTypeOperation))
-        case None => None
-      }
+      operationProps.get(typeOperation).flatMap(operation =>
+        Option(operation).flatMap(op => Some(getTypeOperationByName(op.toString, defaultTypeOperation))))
     } else None
 }

--- a/sdk/src/test/scala/com/stratio/sparkta/sdk/OperatorTest.scala
+++ b/sdk/src/test/scala/com/stratio/sparkta/sdk/OperatorTest.scala
@@ -18,11 +18,10 @@ package com.stratio.sparkta.sdk
 
 import java.io.{Serializable => JSerializable}
 
+import com.stratio.sparkta.sdk.test.{OperatorMock, OperatorMockString}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{Matchers, WordSpec}
-
-import com.stratio.sparkta.sdk.test.{OperatorMock, OperatorMockString}
 
 @RunWith(classOf[JUnitRunner])
 class OperatorTest extends WordSpec with Matchers {
@@ -251,6 +250,48 @@ class OperatorTest extends WordSpec with Matchers {
       val operator = new OperatorMock("opTest", Map())
       val expected = TypeOp.Long
       val result = operator.returnType
+      result should be(expected)
+    }
+
+    "Operation associativity must be " in {
+      val operator = new OperatorMock("opTest", Map())
+      val expected = false
+      val result = operator.isAssociative
+      result should be(expected)
+    }
+
+    "Operation extract old values must be " in {
+      val operator = new OperatorMock("opTest", Map())
+      val expected = Seq(1)
+      val result = operator.extractValues(Seq((Operator.OldValuesKey, Some(1))), Some(Operator.OldValuesKey))
+      result should be(expected)
+    }
+
+    "Operation extract new values must be " in {
+      val operator = new OperatorMock("opTest", Map())
+      val expected = Seq(1)
+      val result = operator.extractValues(Seq((Operator.NewValuesKey, Some(1))), Some(Operator.NewValuesKey))
+      result should be(expected)
+    }
+
+    "Operation extract old values must be empty " in {
+      val operator = new OperatorMock("opTest", Map())
+      val expected = Seq()
+      val result = operator.extractValues(Seq((Operator.NewValuesKey, Some(1))), Some(Operator.OldValuesKey))
+      result should be(expected)
+    }
+
+    "Operation extract new values must be empty " in {
+      val operator = new OperatorMock("opTest", Map())
+      val expected = Seq()
+      val result = operator.extractValues(Seq((Operator.OldValuesKey, Some(1))), Some(Operator.NewValuesKey))
+      result should be(expected)
+    }
+
+    "Operation extract values must be " in {
+      val operator = new OperatorMock("opTest", Map())
+      val expected = Seq(1)
+      val result = operator.extractValues(Seq((Operator.OldValuesKey, Some(1))), None)
       result should be(expected)
     }
 

--- a/serving-core/src/main/scala/com/stratio/sparkta/serving/core/constants/AppConstant.scala
+++ b/serving-core/src/main/scala/com/stratio/sparkta/serving/core/constants/AppConstant.scala
@@ -43,6 +43,7 @@ object AppConstant {
   final val PoliciesBasePath = s"${AppConstant.BaseZKPath}/policies"
   final val ContextPath = s"${AppConstant.BaseZKPath}/contexts"
   final val ConfigRememberPartitioner = "rememberPartitioner"
+  final val DefaultRememberPartitioner = true
   final val ConfigStopGracefully = "stopGracefully"
 
   //Hdfs Options

--- a/test-at/pom.xml
+++ b/test-at/pom.xml
@@ -51,6 +51,10 @@
             <artifactId>serving-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.stratio.sparkta</groupId>
+            <artifactId>sdk</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.fge</groupId>
             <artifactId>json-schema-validator</artifactId>
             <version>2.2.6</version>

--- a/test-at/src/test/resources/policies/ISocket-OMongo-operators.json
+++ b/test-at/src/test/resources/policies/ISocket-OMongo-operators.json
@@ -185,6 +185,14 @@
             "inputField": "text",
             "split": " "
           }
+        },
+        {
+          "name": "entityCount_text",
+          "type": "EntityCount",
+          "configuration": {
+            "inputField": "text",
+            "split": " "
+          }
         }
       ]
     }

--- a/test-at/src/test/resources/policies/ISocket-OMongo-operators.json
+++ b/test-at/src/test/resources/policies/ISocket-OMongo-operators.json
@@ -10,15 +10,15 @@
     "path": "myTestParquetPath"
   },
   "input":
-    {
-      "name": "in-socket",
-      "type": "Socket",
-      "configuration": {
-        "hostname": "localhost",
-        "port": "10666"
-      }
+  {
+    "name": "in-socket",
+    "type": "Socket",
+    "configuration": {
+      "hostname": "localhost",
+      "port": "10666"
     }
-  ,
+  }
+,
   "transformations": [
     {
       "name": "morphline-parser",
@@ -176,14 +176,6 @@
           "type": "Variance",
           "configuration": {
             "inputField": "price"
-          }
-        },
-        {
-          "name": "entityCount_text",
-          "type": "EntityCount",
-          "configuration": {
-            "inputField": "text",
-            "split": " "
           }
         },
         {


### PR DESCRIPTION
#### Description
* SPARKTA-78

* New Cube with two modes of aggregations: associative and non associative way. 
If we want make one cube mixing associative and non associative operations, now is possible.

* With this feature the RAM consumption is exponentially less.

* All the operators are been changed in order to work with this new mode. 

#### Reviewer
@anistal 

#### Test

Some tests are been added  to check this new functionality.
