### PR TITLE
Upgrade to Spark 1.5.1

### DIFF
--- a/benchmark/src/main/resources/benchmark_policy.json
+++ b/benchmark/src/main/resources/benchmark_policy.json
@@ -3,7 +3,6 @@
   "sparkStreamingWindow": 2000,
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "checkpointing": {

--- a/doc/src/site/sphinx/rawdata.rst
+++ b/doc/src/site/sphinx/rawdata.rst
@@ -15,7 +15,6 @@ The following code is an example of the policy block that is needed to setup the
 
   "rawData": {
     "enabled": "true",
-    "partitionFormat": "day",
     "path": "myParquetPath"
   }
 
@@ -27,6 +26,4 @@ The following code is an example of the policy block that is needed to setup the
 | path              | This is the path where the temporal data is going to be saved, this path| Yes (default:default)  |
 |                   | should point to a distributed file system as HDFS, S3,...               |                        |
 +-------------------+-------------------------------------------------------------------------+------------------------+
-| partitionFormat   | This is the granularity to make partitions into folders in the          | Yes (default: day)     |
-|                   | distributed file system. The path will be /year/month/day/ by default.  |                        |
-+-------------------+-------------------------------------------------------------------------+------------------------+
+

--- a/doc/src/site/sphinx/usingSparkta.rst
+++ b/doc/src/site/sphinx/usingSparkta.rst
@@ -89,7 +89,6 @@ In this part you have to define the global parameters of your policy::
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "true",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   }
 +--------------------------+-----------------------------------------------+----------+

--- a/driver/src/main/scala/com/stratio/sparkta/driver/SparktaJob.scala
+++ b/driver/src/main/scala/com/stratio/sparkta/driver/SparktaJob.scala
@@ -206,7 +206,7 @@ object SparktaJob extends SLF4JLogging {
       require(!apConfig.rawData.path.equals("default"), "The parquet path must be set")
       val sqlContext = sqc.getOrElse(SparkContextFactory.sparkSqlContextInstance.get)
       def rawDataStorage: RawDataStorageService =
-        new RawDataStorageService(sqlContext, apConfig.rawData.path, apConfig.rawData.partitionFormat)
+        new RawDataStorageService(sqlContext, apConfig.rawData.path)
       rawDataStorage.save(input)
     }
 

--- a/driver/src/main/scala/com/stratio/sparkta/driver/factory/SchemaFactory.scala
+++ b/driver/src/main/scala/com/stratio/sparkta/driver/factory/SchemaFactory.scala
@@ -25,10 +25,13 @@ import com.stratio.sparkta.sdk._
 
 object SchemaFactory {
 
+  final val Default_Precision = 10
+  final val Default_Scale = 0
+
   val mapTypes = Map(
     TypeOp.Long -> LongType,
     TypeOp.Double -> DoubleType,
-    TypeOp.BigDecimal -> DecimalType(None),
+    TypeOp.BigDecimal -> DecimalType(Default_Precision, Default_Scale),
     TypeOp.Int -> IntegerType,
     TypeOp.Boolean -> BooleanType,
     TypeOp.Date -> DateType,

--- a/driver/src/main/scala/com/stratio/sparkta/driver/service/RawDataStorageService.scala
+++ b/driver/src/main/scala/com/stratio/sparkta/driver/service/RawDataStorageService.scala
@@ -16,6 +16,8 @@
 
 package com.stratio.sparkta.driver.service
 
+import java.sql.Timestamp
+
 import com.stratio.sparkta.sdk.{DateOperations, Event, Input}
 import org.apache.spark.sql._
 import org.apache.spark.streaming.dstream.DStream
@@ -24,19 +26,17 @@ import org.apache.spark.streaming.dstream.DStream
  * Saves the raw data from a stream in Parquet.
  * @author arincon
  */
-class RawDataStorageService(sc: SQLContext, path: String, partitionFormat: String) extends Serializable {
+class RawDataStorageService(sc: SQLContext, path: String) extends Serializable {
 
   import sc.implicits._
 
-  case class RawEvent(timeStamp: String, data: String)
-
-  val timeSuffix = DateOperations.generateParquetPath(parquetPattern = Some((partitionFormat)))
+  case class RawEvent(timeStamp: Timestamp, data: String)
 
   /**
    * From an event, it tries to parse the raw data in this order:
-   *   it looks if exists Raw field.
-   *   it looks if exists RawDataKey field.
-   *   It compose all values from the event separated with ###
+   * it looks if exists Raw field.
+   * it looks if exists RawDataKey field.
+   * It compose all values from the event separated with ###
    * @param event to parse
    * @return the raw data as a string.
    */
@@ -44,7 +44,7 @@ class RawDataStorageService(sc: SQLContext, path: String, partitionFormat: Strin
     event.rawData.getOrElse(
       if (event.keyMap.size == 1 && event.keyMap.head._1.equals(Input.RawDataKey))
         event.keyMap.head._2.toString
-      else event.keyMap.map(e => e._2).mkString("###")
+      else event.keyMap.values.mkString("###")
     ).toString
 
   /**
@@ -53,13 +53,12 @@ class RawDataStorageService(sc: SQLContext, path: String, partitionFormat: Strin
    * @return the original stream.
    */
   def save(raw: DStream[Event]): DStream[Event] = {
-    raw.map(event => {
-      RawEvent(System.currentTimeMillis().toString, extractRawFromEvent(event))
-    }).foreachRDD(_.toDF()
-      .write
-      .format("parquet")
-      .mode(SaveMode.Append)
-      .save(s"$path$timeSuffix"))
+    raw.map(event => RawEvent(DateOperations.millisToTimeStamp(System.currentTimeMillis()), extractRawFromEvent(event)))
+      .foreachRDD(rdd => rdd.toDF()
+        .write
+        .format("parquet")
+        .mode(SaveMode.Append)
+        .save(s"$path"))
     raw
   }
 }

--- a/driver/src/main/scala/com/stratio/sparkta/driver/service/RawDataStorageService.scala
+++ b/driver/src/main/scala/com/stratio/sparkta/driver/service/RawDataStorageService.scala
@@ -57,6 +57,8 @@ class RawDataStorageService(sc: SQLContext, path: String) extends Serializable {
       .foreachRDD(rdd => rdd.toDF()
         .write
         .format("parquet")
+        //FIXME when .partitionBy is stable in Spark we can activate this line
+        //.partitionBy("timeStamp")
         .mode(SaveMode.Append)
         .save(s"$path"))
     raw

--- a/driver/src/test/resources/policies/ISocket-OMongo.json
+++ b/driver/src/test/resources/policies/ISocket-OMongo.json
@@ -4,7 +4,6 @@
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "input":

--- a/driver/src/test/scala/com/stratio/sparkta/driver/test/service/RawDataStorageIT.scala
+++ b/driver/src/test/scala/com/stratio/sparkta/driver/test/service/RawDataStorageIT.scala
@@ -39,7 +39,7 @@ class RawDataStorageIT extends TestSuiteBase {
   val SleepTime: Long = 2000
 
   test("Write and read events in/from parquet") {
-    val rds = new RawDataStorageService(sparktaTestSQLContext, path, "day")
+    val rds = new RawDataStorageService(sparktaTestSQLContext, path)
     //This is not a test, This is a way to feed parquet
     intercept[SparkException] {
       //ArrayStoreException:BoxedUnit
@@ -55,11 +55,11 @@ class RawDataStorageIT extends TestSuiteBase {
     Thread.sleep(SleepTime)
 
     try {
-      val pqFile = sparktaTestSQLContext.read.parquet(path + rds.timeSuffix)
+      val pqFile = sparktaTestSQLContext.read.parquet(path)
       assert(pqFile.count() == ExpectedResult)
     } finally {
       //We can't use the before method
-      val file = new File(path + rds.timeSuffix)
+      val file = new File(path)
       deleteParquetFiles(file)
     }
   }
@@ -106,7 +106,7 @@ class RawDataStorageIT extends TestSuiteBase {
 
   private def deleteParquetFiles(file: File): Unit = {
     if (file.exists() && file.isDirectory)
-      Option(file.listFiles).map(_.toList).getOrElse(Nil).foreach(deleteParquetFiles(_))
+      Option(file.listFiles).map(_.toList).getOrElse(Nil).foreach(deleteParquetFiles)
     file.delete()
   }
 }

--- a/driver/src/test/scala/com/stratio/sparkta/driver/test/service/RawDataStorageTest.scala
+++ b/driver/src/test/scala/com/stratio/sparkta/driver/test/service/RawDataStorageTest.scala
@@ -25,9 +25,9 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class RawDataStorageTest extends FlatSpec with ShouldMatchers {
-  val service = new RawDataStorageService(null, "", "")
+  val service = new RawDataStorageService(null, "")
   "RawDataStorage" should "return a event" in {
-    val service = new RawDataStorageService(null, "", "")
+    val service = new RawDataStorageService(null, "")
     val inputEvent = new Event(Map(Input.RawDataKey -> "hola"))
 
     val result = service.extractRawFromEvent(inputEvent)
@@ -35,13 +35,13 @@ class RawDataStorageTest extends FlatSpec with ShouldMatchers {
     result should be("hola")
   }
   it should "return a raw event" in {
-    val service = new RawDataStorageService(null, "", "")
+    val service = new RawDataStorageService(null, "")
     val inputEvent = new Event(Map(Input.RawDataKey -> "hola"), Some("rawData"))
     val result = service.extractRawFromEvent(inputEvent)
     result should be("rawData")
   }
   it should "return a raw " in {
-    val service = new RawDataStorageService(null, "", "")
+    val service = new RawDataStorageService(null, "")
     val inputEvent = new Event(Map("other key" -> "hola","other one" -> "adios"))
     val result = service.extractRawFromEvent(inputEvent)
     result should be("hola###adios")

--- a/examples/data-generators/ecommerce/ecommerce-policy.json
+++ b/examples/data-generators/ecommerce/ecommerce-policy.json
@@ -5,7 +5,6 @@
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "input":

--- a/examples/data-generators/twitter-to-rabbit/twitter-policy.json
+++ b/examples/data-generators/twitter-to-rabbit/twitter-policy.json
@@ -4,7 +4,7 @@
   "sparkStreamingWindow": 6000,
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
+
     "path": "myTestParquetPath"
   },
   "checkpointPath": "checkpoint",

--- a/examples/policies/IFlume-OMongo.json
+++ b/examples/policies/IFlume-OMongo.json
@@ -5,7 +5,6 @@
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "input":

--- a/examples/policies/IKafka-OMongo.json
+++ b/examples/policies/IKafka-OMongo.json
@@ -5,7 +5,6 @@
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "input":

--- a/examples/policies/IKafka-OPrint.json
+++ b/examples/policies/IKafka-OPrint.json
@@ -4,7 +4,6 @@
   "sparkStreamingWindow": 2000,
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "checkpointPath": "checkpoint",

--- a/examples/policies/IKafkaDirect-OElasticsearch.json
+++ b/examples/policies/IKafkaDirect-OElasticsearch.json
@@ -5,7 +5,6 @@
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "input":

--- a/examples/policies/IRabbit-OPrint.json
+++ b/examples/policies/IRabbit-OPrint.json
@@ -4,7 +4,6 @@
   "sparkStreamingWindow": 2000,
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "checkpointPath": "checkpoint",

--- a/examples/policies/ITwitterJson-OCassandra.json
+++ b/examples/policies/ITwitterJson-OCassandra.json
@@ -5,7 +5,6 @@
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "input": {

--- a/examples/policies/ITwitterJson-OCsv.json.json
+++ b/examples/policies/ITwitterJson-OCsv.json.json
@@ -5,7 +5,6 @@
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "input": {

--- a/examples/policies/IWebSocket-OMongo.json
+++ b/examples/policies/IWebSocket-OMongo.json
@@ -5,7 +5,6 @@
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "input":

--- a/examples/policies/Twitter-Stratio-Example.json
+++ b/examples/policies/Twitter-Stratio-Example.json
@@ -5,7 +5,7 @@
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
+
     "path": "myTestParquetPath"
   },
   "input": {

--- a/examples/policies/fragments/IWebSocket-OCassandra.json
+++ b/examples/policies/fragments/IWebSocket-OCassandra.json
@@ -4,7 +4,6 @@
   "sparkStreamingWindow": 2000,
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "checkpointPath": "checkpoint",

--- a/examples/policies/fragments/IWebSocket-OElasticsearch.json
+++ b/examples/policies/fragments/IWebSocket-OElasticsearch.json
@@ -4,7 +4,6 @@
   "sparkStreamingWindow": 2000,
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "checkpointPath": "checkpoint",

--- a/examples/policies/fragments/IWebSocket-OMongo.json
+++ b/examples/policies/fragments/IWebSocket-OMongo.json
@@ -4,7 +4,6 @@
   "sparkStreamingWindow": 2000,
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "checkpointPath": "checkpoint",

--- a/examples/policies/fragments/IWebSocket-OPrint.json
+++ b/examples/policies/fragments/IWebSocket-OPrint.json
@@ -4,7 +4,6 @@
   "sparkStreamingWindow": 2000,
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "checkpointPath": "checkpoint",

--- a/plugins/output-cassandra/pom.xml
+++ b/plugins/output-cassandra/pom.xml
@@ -25,11 +25,16 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>output-cassandra</artifactId>
+
+    <properties>
+        <cassandra.spark.version>1.5.0-M2</cassandra.spark.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.datastax.spark</groupId>
             <artifactId>spark-cassandra-connector_2.10</artifactId>
-            <version>1.5.0-M2</version>
+            <version>${cassandra.spark.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/plugins/output-cassandra/pom.xml
+++ b/plugins/output-cassandra/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.datastax.spark</groupId>
             <artifactId>spark-cassandra-connector_2.10</artifactId>
-            <version>1.4.0-M3</version>
+            <version>1.5.0-M2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/plugins/output-csv/pom.xml
+++ b/plugins/output-csv/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.databricks</groupId>
             <artifactId>spark-csv_${scala.binary.version}</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/plugins/output-csv/src/main/scala/com/stratio/sparkta/plugin/output/csv/CsvOutput.scala
+++ b/plugins/output-csv/src/main/scala/com/stratio/sparkta/plugin/output/csv/CsvOutput.scala
@@ -45,6 +45,8 @@ class CsvOutput(keyName: String,
 
   val header = Try(properties.getString("header").toBoolean).getOrElse(false)
 
+  val inferSchema = Try(properties.getString("inferSchema").toBoolean).getOrElse(false)
+
   val delimiter = getValidDelimiter(properties.getString("delimiter", ","))
 
   val datePattern = properties.getString("datePattern", None)
@@ -61,7 +63,7 @@ class CsvOutput(keyName: String,
   protected[csv] def saveAction(path: String, dataFrame: DataFrame): Unit = {
     import com.databricks.spark.csv.CsvSchemaRDD
     dataFrame.saveAsCsvFile(path,
-      Map("header" -> header.toString, "delimiter" -> delimiter))
+      Map("header" -> header.toString, "delimiter" -> delimiter, "inferSchema" -> inferSchema.toString))
   }
 
   def getValidDelimiter(delimiter: String) : String = {

--- a/plugins/output-elasticsearch/pom.xml
+++ b/plugins/output-elasticsearch/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <elasticsearch.version>1.7.3</elasticsearch.version>
         <elastic4s.version>1.7.4</elastic4s.version>
-        <elastic.spark.version>2.1.2</elastic.spark.version>
+        <elastic.spark.version>2.2.0-beta1</elastic.spark.version>
     </properties>
 
     <dependencies>

--- a/plugins/output-elasticsearch/pom.xml
+++ b/plugins/output-elasticsearch/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <elasticsearch.version>1.7.3</elasticsearch.version>
         <elastic4s.version>1.7.4</elastic4s.version>
-        <elastic.spark.version>2.2.0-beta1</elastic.spark.version>
+        <elastic.spark.version>2.1.2</elastic.spark.version>
     </properties>
 
     <dependencies>

--- a/plugins/output-elasticsearch/src/main/scala/com/stratio/sparkta/plugin/output/elasticsearch/dao/ElasticSearchDAO.scala
+++ b/plugins/output-elasticsearch/src/main/scala/com/stratio/sparkta/plugin/output/elasticsearch/dao/ElasticSearchDAO.scala
@@ -21,7 +21,6 @@ import com.stratio.sparkta.sdk.{TypeOp, _}
 
 trait ElasticSearchDAO {
 
-  final val TimestampPattern = "@timestamp:"
   final val DefaultIndexType = "sparkta"
   final val DefaultNode = "localhost"
   final val DefaultTcpPort = "9300"
@@ -34,7 +33,8 @@ trait ElasticSearchDAO {
   // this regex pretend validate all localhost loopback values including ipv6
   final val LocalhostPattern = "^localhost$|^127(?:\\.[0-9]+){0,2}\\.[0-9]+$|^(?:0*\\:)*?:?0*1$".r.pattern
 
-  val dateTypeMap = Map("timestamp" -> TypeOp.Timestamp, "date" -> TypeOp.Date, "datetime" -> TypeOp.DateTime)
+  val dateTypeMap = Map("timestamp" -> TypeOp.Timestamp, "date" -> TypeOp.Date, "datetime" -> TypeOp.DateTime,
+    "long" -> TypeOp.Long, "string" -> TypeOp.String)
 
   def tcpNodes: Seq[(String, Int)]
 
@@ -56,13 +56,13 @@ trait ElasticSearchDAO {
   } ++
     Map("es.nodes" -> httpNodes(0)._1, "es.port" -> httpNodes(0)._2.toString, "es.index.auto.create" -> "no") ++ {
     if (timeName.isEmpty) Map()
-    else Map("es.mapping.names" -> s"$timeName:@timestamp")
+    else Map("es.mapping.timestamp" -> timeName)
   }
 
   def getDateTimeType(dateType: Option[String]): TypeOp = {
     dateType match {
-      case None => TypeOp.String
-      case Some(date) => dateTypeMap.get(date.toLowerCase).getOrElse(TypeOp.String)
+      case None => TypeOp.Long
+      case Some(date) => dateTypeMap.getOrElse(date.toLowerCase, TypeOp.String)
     }
   }
 }

--- a/plugins/output-elasticsearch/src/test/scala/com/stratio/sparkta/plugin/output/elasticsearch/dao/ElasticSearchDaoTest.scala
+++ b/plugins/output-elasticsearch/src/test/scala/com/stratio/sparkta/plugin/output/elasticsearch/dao/ElasticSearchDaoTest.scala
@@ -33,7 +33,7 @@ class ElasticSearchDAOTest extends FlatSpec with ShouldMatchers {
 
     val baseMap = Map("es.nodes" -> "localhost", "es.port" -> "9200", "es.index.auto.create" -> "no")
     val providedMap = Map("es.mapping.id" -> "id")
-    val tsMap = Map("es.mapping.names" -> "minutes:@timestamp")
+    val tsMap = Map("es.mapping.timestamp" -> "minutes")
     val expectedProvided = providedMap ++ baseMap
     val expectedWithTs = baseMap ++ tsMap
     val expectedProvidedWithTs = expectedProvided ++ tsMap
@@ -47,7 +47,7 @@ class ElasticSearchDAOTest extends FlatSpec with ShouldMatchers {
   }
 
   it should "return a valid TypeOp from dateType" in new BaseValues {
-    dao.getDateTimeType(None) should be(TypeOp.String)
+    dao.getDateTimeType(None) should be(TypeOp.Long)
     dao.getDateTimeType(Some("timestamp")) should be(TypeOp.Timestamp)
     dao.getDateTimeType(Some("date")) should be(TypeOp.Date)
     dao.getDateTimeType(Some("datetime")) should be(TypeOp.DateTime)

--- a/plugins/output-mongodb/pom.xml
+++ b/plugins/output-mongodb/pom.xml
@@ -1,13 +1,13 @@
 
 <!--
 
-    Copyright (C) 2014 Stratio (http://stratio.com)
+    Copyright (C) 2015 Stratio (http://stratio.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -39,9 +39,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.stratio</groupId>
-            <artifactId>spark-mongodb-core</artifactId>
-            <version>0.8.7</version>
+            <groupId>com.stratio.datasource</groupId>
+            <artifactId>spark-mongodb_${scala.binary.version}</artifactId>
+            <version>0.10.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/plugins/output-mongodb/pom.xml
+++ b/plugins/output-mongodb/pom.xml
@@ -26,12 +26,17 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <properties>
+        <casbah.version>2.8.0</casbah.version>
+        <mongodb.spark.version>0.10.1</mongodb.spark.version>
+    </properties>
+
     <artifactId>output-mongodb</artifactId>
     <dependencies>
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>casbah-core_${scala.binary.version}</artifactId>
-            <version>2.8.0</version>
+            <version>${casbah.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
@@ -41,7 +46,7 @@
         <dependency>
             <groupId>com.stratio.datasource</groupId>
             <artifactId>spark-mongodb_${scala.binary.version}</artifactId>
-            <version>0.10.1</version>
+            <version>${mongodb.spark.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/plugins/output-mongodb/src/main/scala/com/stratio/sparkta/plugin/output/mongodb/MongoDbOutput.scala
+++ b/plugins/output-mongodb/src/main/scala/com/stratio/sparkta/plugin/output/mongodb/MongoDbOutput.scala
@@ -87,8 +87,8 @@ class MongoDbOutput(keyName : String,
 
   private def getPrimaryKeyOptions(timeDimension : String) : Map[String, String] =
     if (!timeDimension.isEmpty) {
-      Map("searchFields" -> Seq(Output.Id, timeDimension).mkString(","))
-    } else Map("searchFields" -> Output.Id)
+      Map("updateFields" -> Seq(Output.Id, timeDimension).mkString(","))
+    } else Map("updateFields" -> Output.Id)
 
   private def getConnectionConfs(key : String, firstJsonItem : String, secondJsonItem : String) : String = {
     val conObj = properties.getConnectionChain(key)

--- a/plugins/output-mongodb/src/main/scala/com/stratio/sparkta/plugin/output/mongodb/MongoDbOutput.scala
+++ b/plugins/output-mongodb/src/main/scala/com/stratio/sparkta/plugin/output/mongodb/MongoDbOutput.scala
@@ -19,6 +19,7 @@ package com.stratio.sparkta.plugin.output.mongodb
 import java.io.{Serializable => JSerializable}
 
 import com.mongodb.casbah.commons.conversions.scala._
+import com.stratio.datasource.mongodb.MongodbConfig
 import com.stratio.sparkta.plugin.output.mongodb.dao.MongoDbDAO
 import com.stratio.sparkta.sdk.TypeOp._
 import com.stratio.sparkta.sdk.ValidatingPropertyMap._
@@ -28,11 +29,11 @@ import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.SaveMode._
 import org.apache.spark.streaming.dstream.DStream
 
-class MongoDbOutput(keyName : String,
-                    version : Option[Int],
-                    properties : Map[String, JSerializable],
-                    operationTypes : Option[Map[String, (WriteOp, TypeOp)]],
-                    bcSchema : Option[Seq[TableSchema]])
+class MongoDbOutput(keyName: String,
+                    version: Option[Int],
+                    properties: Map[String, JSerializable],
+                    operationTypes: Option[Map[String, (WriteOp, TypeOp)]],
+                    bcSchema: Option[Seq[TableSchema]])
   extends Output(keyName, version, properties, operationTypes, bcSchema) with MongoDbDAO {
 
   RegisterJodaTimeConversionHelpers()
@@ -53,7 +54,7 @@ class MongoDbOutput(keyName : String,
 
   override val language = properties.getString("language", None)
 
-  override def setup : Unit = {
+  override def setup: Unit = {
     if (bcSchema.isDefined) {
       val db = connectToDatabase
       val schemasFiltered =
@@ -64,33 +65,33 @@ class MongoDbOutput(keyName : String,
     }
   }
 
-  override def doPersist(stream : DStream[(DimensionValuesTime, Map[String, Option[Any]])]) : Unit = {
+  override def doPersist(stream: DStream[(DimensionValuesTime, Map[String, Option[Any]])]): Unit = {
     persistDataFrame(stream)
   }
 
-  override def upsert(dataFrame : DataFrame, tableName : String, timeDimension : String) : Unit = {
+  override def upsert(dataFrame: DataFrame, tableName: String, timeDimension: String): Unit = {
     val options = getDataFrameOptions(tableName, timeDimension)
     dataFrame.write
-      .format("com.stratio.provider.mongodb")
+      .format(MongoDbSparkDatasource)
       .mode(Append)
       .options(options)
       .save()
   }
 
-  private def getDataFrameOptions(tableName : String, timeDimension : String) : Map[String, String] =
+  private def getDataFrameOptions(tableName: String, timeDimension: String): Map[String, String] =
     Map(
-      "host" -> hosts,
-      "database" -> dbName,
-      "collection" -> tableName) ++ getPrimaryKeyOptions(timeDimension) ++ {
-      if (language.isDefined) Map("language" -> language.get) else Map()
+      MongodbConfig.Host -> hosts,
+      MongodbConfig.Database -> dbName,
+      MongodbConfig.Collection -> tableName) ++ getPrimaryKeyOptions(timeDimension) ++ {
+      if (language.isDefined) Map(MongodbConfig.Language -> language.get) else Map()
     }
 
-  private def getPrimaryKeyOptions(timeDimension : String) : Map[String, String] =
+  private def getPrimaryKeyOptions(timeDimension: String): Map[String, String] =
     if (!timeDimension.isEmpty) {
-      Map("updateFields" -> Seq(Output.Id, timeDimension).mkString(","))
-    } else Map("updateFields" -> Output.Id)
+      Map(MongodbConfig.UpdateFields -> Seq(Output.Id, timeDimension).mkString(","))
+    } else Map(MongodbConfig.UpdateFields -> Output.Id)
 
-  private def getConnectionConfs(key : String, firstJsonItem : String, secondJsonItem : String) : String = {
+  private def getConnectionConfs(key: String, firstJsonItem: String, secondJsonItem: String): String = {
     val conObj = properties.getConnectionChain(key)
     conObj.map(c => {
       val host = c.getOrElse(firstJsonItem, DefaultHost)

--- a/plugins/output-mongodb/src/main/scala/com/stratio/sparkta/plugin/output/mongodb/dao/MongoDbDAO.scala
+++ b/plugins/output-mongodb/src/main/scala/com/stratio/sparkta/plugin/output/mongodb/dao/MongoDbDAO.scala
@@ -37,6 +37,7 @@ trait MongoDbDAO extends Logging {
   final val DefaultWriteConcern = casbah.WriteConcern.Unacknowledged
   final val DefaultHost = "localhost"
   final val DefaultPort = "27017"
+  final val MongoDbSparkDatasource = "com.stratio.datasource.mongodb"
 
   def hosts : String
 

--- a/plugins/output-parquet/src/main/scala/com/stratio/sparkta/plugin/output/parquet/ParquetOutput.scala
+++ b/plugins/output-parquet/src/main/scala/com/stratio/sparkta/plugin/output/parquet/ParquetOutput.scala
@@ -43,8 +43,10 @@ class ParquetOutput(keyName: String,
   override def upsert(dataFrame: DataFrame, tableName: String, timeDimension: String): Unit = {
     val path = properties.getString("path", None)
     require(path.isDefined, "Destination path is required. You have to set 'path' on properties")
-    val subPath = DateOperations.generateParquetPath()
 
-    dataFrame.write.format("parquet").mode(Overwrite).save(s"${path.get}/${versionedTableName(tableName)}$subPath")
+    dataFrame.write.format("parquet")
+      .partitionBy(timeDimension)
+      .mode(Overwrite)
+      .save(s"${path.get}/${versionedTableName(tableName)}")
   }
 }

--- a/plugins/output-parquet/src/test/scala/com/stratio/sparkta/plugin/output/parquet/ParquetOutputIT.scala
+++ b/plugins/output-parquet/src/test/scala/com/stratio/sparkta/plugin/output/parquet/ParquetOutputIT.scala
@@ -16,7 +16,7 @@
 
 package com.stratio.sparkta.plugin.output.parquet
 
-import scala.reflect.io.File
+import java.sql.Timestamp
 
 import com.github.nscala_time.time.Imports._
 import org.apache.log4j.{Level, Logger}
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith
 import org.scalatest._
 import org.scalatest.junit.JUnitRunner
 
-import com.stratio.sparkta.sdk.DateOperations
+import scala.reflect.io.File
 
 @RunWith(classOf[JUnitRunner])
 class ParquetOutputIT extends FlatSpec with ShouldMatchers with BeforeAndAfterAll {
@@ -50,7 +50,10 @@ class ParquetOutputIT extends FlatSpec with ShouldMatchers with BeforeAndAfterAl
 
     import sqlContext.implicits._
 
-    val data = sc.parallelize(Seq(Person("Kevin", 18), Person("Kira", 21), Person("Ariadne", 26))).toDF
+    val time = new Timestamp(DateTime.now.getMillis)
+
+    val data = sc.parallelize(Seq(Person("Kevin", 18, time), Person("Kira", 21, time), Person("Ariadne", 26, time)))
+      .toDF
     val tmpPath: String = File.makeTemp().name
   }
 
@@ -84,7 +87,6 @@ class ParquetOutputIT extends FlatSpec with ShouldMatchers with BeforeAndAfterAl
   it should "throw an exception when path is not present" in new WithWrongOutput {
     an[Exception] should be thrownBy output.upsert(data, "person", "minute")
   }
-
 }
 
 object ParquetOutputIT {
@@ -93,4 +95,4 @@ object ParquetOutputIT {
     new SparkContext(s"local[$numExecutors]", title)
 }
 
-case class Person(name: String, age: Int) extends Serializable
+case class Person(name: String, age: Int, minute: Timestamp) extends Serializable

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <maven.compiler.target>1.7</maven.compiler.target>
         <scala.binary.version>2.10</scala.binary.version>
         <scala.version>2.10.4</scala.version>
-        <spark.version>1.4.1</spark.version>
+        <spark.version>1.5.2</spark.version>
         <slf4j.version>1.7.7</slf4j.version>
         <nscala.time.version>2.0.0</nscala.time.version>
         <scalatest.version>2.2.2</scalatest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <maven.compiler.target>1.7</maven.compiler.target>
         <scala.binary.version>2.10</scala.binary.version>
         <scala.version>2.10.4</scala.version>
-        <spark.version>1.5.1</spark.version>
+        <spark.version>1.4.1</spark.version>
         <slf4j.version>1.7.7</slf4j.version>
         <nscala.time.version>2.0.0</nscala.time.version>
         <scalatest.version>2.2.2</scalatest.version>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <maven.compiler.target>1.7</maven.compiler.target>
         <scala.binary.version>2.10</scala.binary.version>
         <scala.version>2.10.4</scala.version>
-        <spark.version>1.5.2</spark.version>
+        <spark.version>1.5.1</spark.version>
         <slf4j.version>1.7.7</slf4j.version>
         <nscala.time.version>2.0.0</nscala.time.version>
         <scalatest.version>2.2.2</scalatest.version>

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/DateOperations.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/DateOperations.scala
@@ -24,8 +24,6 @@ import com.github.nscala_time.time.Imports._
 
 object DateOperations {
 
-  val ParquetPathPattern = "/'year='yyyy/'month='MM/'day='dd/'hour='HH/'minute='mm/'second='ss"
-
   def getTimeFromGranularity(timeDimension: Option[String], granularity: Option[String]): Long =
     (timeDimension, granularity) match {
       case (Some(time), Some(granularity)) => dateFromGranularity(DateTime.now, granularity)
@@ -77,23 +75,6 @@ object DateOperations {
     val suffix = dateFromGranularity(DateTime.now, granularity)
     if (!datePattern.isDefined || suffix.equals(0L)) s"/$suffix"
     else s"/${DateTimeFormat.forPattern(datePattern.get).print(new DateTime(suffix))}/$suffix"
-  }
-
-  /**
-   * Generates a parquet path with the format contained in ParquetPathPattern.
-   * @return the object described above.
-   */
-  def generateParquetPath(dateTime: Option[DateTime] = Option(DateTime.now),
-                          parquetPattern: Option[String] = Some(ParquetPathPattern)): String = {
-    val pattern = parquetPattern.get match {
-      case "year" => "/'year='yyyy/'"
-      case "month" => "/'year='yyyy/'month='MM/'"
-      case "day" => "/'year='yyyy/'month='MM/'day='dd/'"
-      case "hour" => "/'year='yyyy/'month='MM/'day='dd/'hour='HH/'"
-      case "minute" => "/'year='yyyy/'month='MM/'day='dd/'hour='HH/'minute='mm/'"
-      case _ => ParquetPathPattern
-    }
-    DateTimeFormat.forPattern(pattern).print(dateTime.get)
   }
 
   def roundDateTime(t: DateTime, d: Duration): DateTime =

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/Output.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/Output.scala
@@ -104,7 +104,7 @@ abstract class Output(keyName: String,
         aggregations,
         fixedAggregation,
         getFixedDimensions(dimensionValuesTime),
-        isAutoCalculateId)
+        isAutoCalculateId, dateType)
     }
       .foreachRDD(rdd => {
         bcSchema.get.filter(tschema => tschema.outputName == keyName).foreach(tschemaFiltered => {
@@ -219,6 +219,7 @@ object Output {
   def getFieldType(dateTimeType: TypeOp, fieldName: String, nullable: Boolean): StructField =
     dateTimeType match {
       case TypeOp.Date | TypeOp.DateTime => defaultDateField(fieldName, nullable)
+      case TypeOp.Long => defaultLongField(fieldName, nullable)
       case TypeOp.Timestamp => defaultTimeStampField(fieldName, nullable)
       case TypeOp.String => defaultStringField(fieldName, nullable)
       case _ => defaultStringField(fieldName, nullable)
@@ -229,6 +230,9 @@ object Output {
 
   def defaultDateField(fieldName: String, nullable: Boolean): StructField =
     StructField(fieldName, DateType, nullable)
+
+  def defaultLongField(fieldName: String, nullable: Boolean): StructField =
+    StructField(fieldName, LongType, nullable)
 
   def defaultStringField(fieldName: String, nullable: Boolean): StructField =
     StructField(fieldName, StringType, nullable)

--- a/sdk/src/test/scala/com/stratio/sparkta/sdk/AggregateOperationsTest.scala
+++ b/sdk/src/test/scala/com/stratio/sparkta/sdk/AggregateOperationsTest.scala
@@ -56,34 +56,39 @@ class AggregateOperationsTest extends FlatSpec with ShouldMatchers {
   it should "return a correct toKeyRow tuple" in new CommonValues {
     val expect = (Some("dim1_dim2_dim3_minute"), Row("value1", "value2", "value3", new Timestamp(1L), "2", "value"))
     val result = AggregateOperations.toKeyRow(
-      dimensionValuesT, aggregations, fixedAggregation, fixedDimensions, false)
+      dimensionValuesT, aggregations, fixedAggregation, fixedDimensions, false, TypeOp.Timestamp)
     result should be(expect)
   }
 
   it should "return a correct toKeyRow tuple without fixedAggregation" in new CommonValues {
     val expect = (Some("dim1_dim2_dim3_minute"), Row("value1", "value2", "value3", new Timestamp(1L), "value"))
-    val result = AggregateOperations.toKeyRow(dimensionValuesT, aggregations, Map(), fixedDimensions, false)
+    val result = AggregateOperations.toKeyRow(dimensionValuesT,
+      aggregations,
+      Map(),
+      fixedDimensions,
+      false,
+      TypeOp.Timestamp)
     result should be(expect)
   }
 
   it should "return a correct toKeyRow tuple without fixedDimensions" in new CommonValues {
     val expect = (Some("dim1_dim2_minute"), Row("value1", "value2", new Timestamp(1L), "2", "value"))
     val result = AggregateOperations.toKeyRow(
-      dimensionValuesT, aggregations, fixedAggregation, None, false)
+      dimensionValuesT, aggregations, fixedAggregation, None, false, TypeOp.Timestamp)
     result should be(expect)
   }
 
   it should "return a correct toKeyRow tuple without fixedDimensions and fixedAggregation" in new CommonValues {
     val expect = (Some("dim1_dim2_minute"), Row("value1", "value2", new Timestamp(1L), "value"))
     val result = AggregateOperations.toKeyRow(
-      dimensionValuesT, aggregations, Map(), None, false)
+      dimensionValuesT, aggregations, Map(), None, false, TypeOp.Timestamp)
     result should be(expect)
   }
 
   it should "return a correct toKeyRow tuple without aggregations and  fixedDimensions and fixedAggregation" in
     new CommonValues {
       val expect = (Some("dim1_dim2_minute"), Row("value1", "value2", new Timestamp(1L)))
-      val result = AggregateOperations.toKeyRow(dimensionValuesT, Map(), Map(), None, false)
+      val result = AggregateOperations.toKeyRow(dimensionValuesT, Map(), Map(), None, false, TypeOp.Timestamp)
       result should be(expect)
     }
 
@@ -92,7 +97,12 @@ class AggregateOperationsTest extends FlatSpec with ShouldMatchers {
     new CommonValues {
       val expect = (Some("minute"), Row(new Timestamp(1L)))
       val result =
-        AggregateOperations.toKeyRow(DimensionValuesTime(Seq(), timestamp, timeDimension), Map(), Map(), None, false)
+        AggregateOperations.toKeyRow(DimensionValuesTime(Seq(), timestamp, timeDimension),
+          Map(),
+          Map(),
+          None,
+          false,
+          TypeOp.Timestamp)
       result should be(expect)
     }
 

--- a/sdk/src/test/scala/com/stratio/sparkta/sdk/DateOperationsTest.scala
+++ b/sdk/src/test/scala/com/stratio/sparkta/sdk/DateOperationsTest.scala
@@ -121,11 +121,6 @@ class DateOperationsTest extends FlatSpec with ShouldMatchers {
     DateOperations.subPath(granularity, datePattern) should be(expectedGranularityWithPattern)
   }
 
-  it should "create a raw data path" in new CommonValues {
-    val formatter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.ZZZ")
-    val now = Option(formatter.parseDateTime("1984-03-17 13:13:13.CET"))
-    DateOperations.generateParquetPath(now) should be(expectedRawPath)
-  }
   it should "round to 15 seconds" in new CommonValues {
     val formatter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.ZZZ")
     val now = formatter.parseDateTime("1984-03-17 13:13:17.CET")
@@ -140,14 +135,6 @@ class DateOperationsTest extends FlatSpec with ShouldMatchers {
     val formatter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.ZZZ")
     val now = formatter.parseDateTime("1984-03-17 13:13:17.CET")
     DateOperations.dateFromGranularity(now, "s5") should be(448373595000L)
-  }
-  it should "create the full parquet path with just a word" in new ParquetPath {
-    DateOperations.generateParquetPath(parquetPattern = Some(yearStr)) should be(yearPatternResult)
-    DateOperations.generateParquetPath(parquetPattern = Some(monthStr)) should be(monthPatternResult)
-    DateOperations.generateParquetPath(parquetPattern = Some(dayStr)) should be(dayPatternResult)
-    DateOperations.generateParquetPath(parquetPattern = Some(hourStr)) should be(hourPatternResult)
-    DateOperations.generateParquetPath(parquetPattern = Some(minuteStr)) should be(minutePatternResult)
-    DateOperations.generateParquetPath(parquetPattern = Some(defaultStr)) should be(defaultPatternResult)
   }
 
   it should "return millis from a Serializable date" in new CommonValues {

--- a/serving-api/src/test/resources/policies/ISocket-OMongo.json
+++ b/serving-api/src/test/resources/policies/ISocket-OMongo.json
@@ -4,7 +4,6 @@
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "input":

--- a/serving-core/src/main/resources/policy_schema.json
+++ b/serving-core/src/main/resources/policy_schema.json
@@ -75,10 +75,6 @@
           "id": "http://sparkta.stratio.com/rawData/enabled",
           "type": "string"
         },
-        "partitionFormat": {
-          "id": "http://sparkta.stratio.com/rawData/partitionFormat",
-          "type": "string"
-        },
         "path": {
           "id": "http://sparkta.stratio.com/rawData/path",
           "type": "string"

--- a/serving-core/src/main/scala/com/stratio/sparkta/serving/core/models/RawDataModel.scala
+++ b/serving-core/src/main/scala/com/stratio/sparkta/serving/core/models/RawDataModel.scala
@@ -18,12 +18,10 @@ package com.stratio.sparkta.serving.core.models
 
 
 case class RawDataModel(enabled: String = RawDataModel.Enabled,
-                      partitionFormat: String = RawDataModel.PartitionFormat,
                       path: String = RawDataModel.Path)
 
 case object RawDataModel {
 
   val Enabled = "false"
-  val PartitionFormat = "day"
   val Path = "default"
 }

--- a/test-at/pom.xml
+++ b/test-at/pom.xml
@@ -223,7 +223,7 @@
         <dependency>
             <groupId>com.datastax.spark</groupId>
             <artifactId>spark-cassandra-connector_${scala.binary.version}</artifactId>
-            <version>1.4.0-M3</version>
+            <version>1.5.0-M2</version>
         </dependency>
         <dependency>
             <groupId>com.databricks</groupId>

--- a/test-at/src/test/resources/policies/ISocket-OCassandra-operators.json
+++ b/test-at/src/test/resources/policies/ISocket-OCassandra-operators.json
@@ -5,7 +5,6 @@
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": ""
   },
   "input":

--- a/test-at/src/test/resources/policies/ISocket-OCassandra.json
+++ b/test-at/src/test/resources/policies/ISocket-OCassandra.json
@@ -5,7 +5,6 @@
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "input":

--- a/test-at/src/test/resources/policies/ISocket-OCsv-operators.json
+++ b/test-at/src/test/resources/policies/ISocket-OCsv-operators.json
@@ -5,7 +5,6 @@
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "input":

--- a/test-at/src/test/resources/policies/ISocket-OElasticsearch-operators.json
+++ b/test-at/src/test/resources/policies/ISocket-OElasticsearch-operators.json
@@ -6,7 +6,6 @@
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": ""
   },
   "input":

--- a/test-at/src/test/resources/policies/ISocket-OElasticsearch.json
+++ b/test-at/src/test/resources/policies/ISocket-OElasticsearch.json
@@ -6,7 +6,6 @@
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "input":

--- a/test-at/src/test/resources/policies/ISocket-OElasticsearchJSON.json
+++ b/test-at/src/test/resources/policies/ISocket-OElasticsearchJSON.json
@@ -6,7 +6,6 @@
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "input":

--- a/test-at/src/test/resources/policies/ISocket-OMongo-operators.json
+++ b/test-at/src/test/resources/policies/ISocket-OMongo-operators.json
@@ -6,7 +6,6 @@
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "input":

--- a/test-at/src/test/resources/policies/ISocket-OParquet-operators.json
+++ b/test-at/src/test/resources/policies/ISocket-OParquet-operators.json
@@ -6,7 +6,6 @@
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "input":

--- a/test-at/src/test/resources/policies/ISocket-ORawData.json
+++ b/test-at/src/test/resources/policies/ISocket-ORawData.json
@@ -6,7 +6,6 @@
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "true",
-    "partitionFormat": "day",
     "path": "/tmp/sparkta/raw"
   },
   "input":

--- a/test-at/src/test/resources/policies/ISocket-ORedis-operators.json
+++ b/test-at/src/test/resources/policies/ISocket-ORedis-operators.json
@@ -6,7 +6,6 @@
   "checkpointPath": "checkpoint",
   "rawData": {
     "enabled": "false",
-    "partitionFormat": "day",
     "path": "myTestParquetPath"
   },
   "input":

--- a/test-at/src/test/scala/com/stratio/sparkta/testat/internal/ISocketOElasticsearchJsonAT.scala
+++ b/test-at/src/test/scala/com/stratio/sparkta/testat/internal/ISocketOElasticsearchJsonAT.scala
@@ -46,12 +46,12 @@ class ISocketOElasticsearchJsonAT extends SparktaATSuite {
     numberOfEventsGrouped(indexName = "id_smfprocess_minute",
       mappingName = "day_v1",
       field = "id",
-      value = "P0001_2015-06-24 11:58:00.0") should be(2d)
+      value = "P0001_1435139880000") should be(2d)
 
     numberOfEventsGrouped(indexName = "id_minute",
       mappingName = "day_v1",
       field = "id",
-      value = "2015-06-24 11:58:00.0") should be(2d)
+      value = "1435139880000") should be(2d)
   }
 
   private def numberOfEventsGrouped(indexName: String, mappingName: String, field: String, value: Any): Double = {

--- a/test-at/src/test/scala/com/stratio/sparkta/testat/outputs/ISocketOParquetOperatorsIT.scala
+++ b/test-at/src/test/scala/com/stratio/sparkta/testat/outputs/ISocketOParquetOperatorsIT.scala
@@ -51,24 +51,25 @@ class ISocketOParquetOperatorsIT extends SparktaATSuite {
     def checkData(): Unit = {
       val sqc = new SQLContext(new SparkContext(s"local[$NumExecutors]", "ISocketOParquet-operators"))
       val df = sqc.read.parquet(parquetPath).toDF
+
       val mapValues = df.map(row => Map(
         "product" -> row.getString(0),
-        "acc_price" -> row.getSeq[String](2),
-        "avg_price" -> row.getDouble(3),
-        "count_price" -> row.getLong(4),
-        "first_price" -> row.getString(6),
-        "fulltext_price" -> row.getString(7),
-        "last_price" -> row.getString(8),
-        "max_price" -> row.getDouble(9),
-        "median_price" -> row.getDouble(10),
-        "min_price" -> row.getDouble(11),
-        "range_price" -> row.getDouble(13),
-        "stddev_price" -> row.getDouble(14),
-        "sum_price" -> row.getDouble(15),
-        "variance_price" -> row.getDouble(17),
-        "mode_price" -> row.getList(12).toArray(),
-        "entityCount_text" -> row.getMap(5),
-        "totalEntity_text" -> row.getInt(16)))
+        "acc_price" -> row.getSeq[String](1),
+        "avg_price" -> row.getDouble(2),
+        "count_price" -> row.getLong(3),
+        "first_price" -> row.getString(5),
+        "fulltext_price" -> row.getString(6),
+        "last_price" -> row.getString(7),
+        "max_price" -> row.getDouble(8),
+        "median_price" -> row.getDouble(9),
+        "min_price" -> row.getDouble(10),
+        "range_price" -> row.getDouble(12),
+        "stddev_price" -> row.getDouble(13),
+        "sum_price" -> row.getDouble(14),
+        "variance_price" -> row.getDouble(16),
+        "mode_price" -> row.getList(11).toArray(),
+        "entityCount_text" -> row.getMap(4),
+        "totalEntity_text" -> row.getInt(15)))
 
       val productA = mapValues.filter(value => value("product") == "producta").take(1)(0)
       productA("acc_price") should be(Seq("10", "500", "1000", "500", "1000", "500", "1002", "600"))

--- a/web/src/data-templates/output.json
+++ b/web/src/data-templates/output.json
@@ -191,6 +191,15 @@
         "qa": "fragment-details-csv-header"
       },
       {
+        "propertyId": "inferSchema",
+        "propertyName": "_INFER_SCHEMA_",
+        "propertyType": "boolean",
+        "regexp": "true|false",
+        "default": false,
+        "required": false,
+        "qa": "fragment-details-csv-inferSchema"
+      },
+      {
         "propertyId": "delimiter",
         "propertyName": "_DELIMITER_",
         "propertyType": "text",

--- a/web/src/data-templates/policy.json
+++ b/web/src/data-templates/policy.json
@@ -2,7 +2,6 @@
   "defaultSparkStreamingWindow": 6000,
   "defaultStorageLevel": "MEMORY_AND_DISK_SER",
   "defaultCheckpointPath": "/tmp/checkpoint",
-  "defaultPartitionFormat": "day",
   "steps": [
     {
       "name": "_POLICY_._STEPS_._DESCRIPTION_",

--- a/web/src/languages/en-US.json
+++ b/web/src/languages/en-US.json
@@ -46,6 +46,7 @@
   "_DATE_FORMAT_": "Date format",
   "_PATH_": "Path",
   "_HEADER_": "Header",
+  "_INFER_SCHEMA_": "Header",
   "_DELIMITER_": "Delimiter",
   "_ID_FIELD_": "Id field",
   "_INDEX_MAPPING_": "Index mapping",

--- a/web/src/languages/en-US.json
+++ b/web/src/languages/en-US.json
@@ -46,7 +46,7 @@
   "_DATE_FORMAT_": "Date format",
   "_PATH_": "Path",
   "_HEADER_": "Header",
-  "_INFER_SCHEMA_": "Header",
+  "_INFER_SCHEMA_": "Infer schema",
   "_DELIMITER_": "Delimiter",
   "_ID_FIELD_": "Id field",
   "_INDEX_MAPPING_": "Index mapping",


### PR DESCRIPTION
#### Description
* SPARKTA-76

* Operators pom's are been updated to the last version. 

* Save Raw data are been modified without partitioner.
* Save Parquet output data are been modified with the new partitioner field (dimensionTime).

* The SDK Aggregate operation are been improved to support changes in the timeDimension, Now can be Long, DateTime, Date and TimeStamp, the default are TimeStamp. This remove the incompatibility in elasticSearch with the TimeStamp fiedl.

* ElasticSearch output save the time in Long type by default, and the mapping are according to the dateType property.

* MongoDb output have new name for the updateFields key.

#### Reviewer
@sgomezg  

#### Test

Some tests are been added and removed to check this new functionality.
