### PR TITLE
Discarding empty DStream

### DIFF
--- a/driver/src/main/scala/com/stratio/sparkta/driver/SparktaJob.scala
+++ b/driver/src/main/scala/com/stratio/sparkta/driver/SparktaJob.scala
@@ -69,6 +69,7 @@ object SparktaJob extends SLF4JLogging {
 
     val outputs = SparktaJob.outputs(apConfig, operatorsKeyOperation, bcCubeOperatorSchema, reflectionUtils)
     val inputEvent = input._2
+
     SparktaJob.saveRawData(apConfig, inputEvent)
     val parsed = SparktaJob.applyParsers(inputEvent, parsers)
     val dataCube = new CubeMaker(cubes).setUp(parsed)
@@ -124,11 +125,11 @@ object SparktaJob extends SLF4JLogging {
 
   def input(apConfig: AggregationPoliciesModel, ssc: StreamingContext, refUtils: ReflectionUtils):
   (String, DStream[Event]) = {
-    val myInput = refUtils.tryToInstantiate[Input](apConfig.input.get.`type` + Input.ClassSuffix, (c) =>
+    val inputInstance = refUtils.tryToInstantiate[Input](apConfig.input.get.`type` + Input.ClassSuffix, (c) =>
       refUtils.instantiateParameterizable[Input](c, apConfig.input.get.configuration))
 
     (apConfig.input.get.name,
-      myInput.setUp(ssc,
+      inputInstance.setUp(ssc,
         apConfig.storageLevel.get))
   }
 

--- a/plugins/input-kafka/src/main/scala/com/stratio/sparkta/plugin/input/kafka/KafkaInput.scala
+++ b/plugins/input-kafka/src/main/scala/com/stratio/sparkta/plugin/input/kafka/KafkaInput.scala
@@ -26,27 +26,25 @@ import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.DStream
 import org.apache.spark.streaming.kafka.KafkaUtils
 
-
 class KafkaInput(properties: Map[String, JSerializable]) extends Input(properties) {
 
-  final val defaultPartition = 1
-  final val defaulPort = "2181"
-  final val defaultHost = "localhost"
+  final val DefaultPartition = 1
+  final val DefaulPort = "2181"
+  final val DefaultHost = "localhost"
 
   override def setUp(ssc: StreamingContext, sparkStorageLevel: String): DStream[Event] = {
-    val submap: Option[Map[String, JSerializable]] = properties.getMap("kafkaParams.")
-    val connection = Map(getZkConnectionConfs("zookeeper.connect", defaultHost, defaulPort))
-    val kafkaParams = submap.get.map(entry => (entry._1, entry._2.toString))
+    val submap = properties.getMap("kafkaParams.")
+    val connection = Map(getZkConnectionConfs("zookeeper.connect", DefaultHost, DefaulPort))
+    val kafkaParams = submap.get.map { case (entry, value) => (entry, value.toString) }
 
-      KafkaUtils.createStream[String, String, StringDecoder, StringDecoder](
-        ssc,
-        connection ++ kafkaParams,
-        extractTopicsMap,
-        storageLevel(sparkStorageLevel))
-        .map(data => new Event(Map(RawDataKey ->{
-        data._2.getBytes("UTF-8").asInstanceOf[java.io.Serializable]
+    KafkaUtils.createStream[String, String, StringDecoder, StringDecoder](
+      ssc,
+      connection ++ kafkaParams,
+      extractTopicsMap(),
+      storageLevel(sparkStorageLevel))
+      .map(data => new Event(Map(RawDataKey -> {
+        data._2.getBytes("UTF-8").asInstanceOf[JSerializable]
       })))
-
   }
 
   def extractTopicsMap(): Map[String, Int] = {
@@ -54,16 +52,15 @@ class KafkaInput(properties: Map[String, JSerializable]) extends Input(propertie
       throw new IllegalStateException(s"Invalid configuration, topics must be declared.")
     }
     else {
-      val topicPartition: Seq[(String, Int)] = getTopicPartition("topics", defaultPartition)
-      val topicPartitionMap = topicPartition.map(tuple=>(tuple._1 -> tuple._2)).toMap
-      topicPartitionMap
+      val topicPartition: Seq[(String, Int)] = getTopicPartition("topics", DefaultPartition)
+      topicPartition.map { case (topic, partition) => topic -> partition }.toMap
     }
   }
 
-  def getTopicPartition(key: String, defaultPartition: Int): Seq[(String, Int)] ={
+  def getTopicPartition(key: String, defaultPartition: Int): Seq[(String, Int)] = {
     val conObj = properties.getConnectionChain(key)
     conObj.map(c =>
-      (c.get("topic") match{
+      (c.get("topic") match {
         case Some(value) => value.toString
         case None => throw new IllegalStateException(s"$key is mandatory")
       },
@@ -77,15 +74,16 @@ class KafkaInput(properties: Map[String, JSerializable]) extends Input(propertie
     val conObj = properties.getConnectionChain(key)
     val value = conObj.map(c => {
       val host = c.get("host") match {
-        case Some(value) => value.toString
+        case Some(hostValue) => hostValue.toString
         case None => defaultHost
       }
       val port = c.get("port") match {
-        case Some(value) => value.toString
+        case Some(portValue) => portValue.toString
         case None => defaultPort
       }
       s"$host:$port"
     }).mkString(",")
+
     (key.toString, value)
   }
 }


### PR DESCRIPTION
#### Description
* SPARKTA-174

* Discard the empty dstream must be in the output in the foreachRDD, if we make this condition in SparktaJob with the size of the object in the JVM or make a DStream extended with the functionality, the streaming run only in this way because is the fist action.

* Refactor Kafka input for scalastyle..


#### Reviewer
@Gschiavon 
