### PR TITLE
Field types in Operator filters

### DIFF
--- a/driver/src/test/scala/com/stratio/sparkta/driver/test/factory/SchemaFactoryTest.scala
+++ b/driver/src/test/scala/com/stratio/sparkta/driver/test/factory/SchemaFactoryTest.scala
@@ -61,7 +61,7 @@ with MockitoSugar {
 
     override val writeOperation = WriteOp.Inc
 
-    override val castingFilterType = TypeOp.Number
+    override val defaultCastingFilterType = TypeOp.Number
 
     override def processMap(inputFields: Map[String, JSerializable]): Option[Any] = {
       None

--- a/plugins/field-default/src/test/scala/com/stratio/sparkta/plugin/field/default/DefaultFieldTest.scala
+++ b/plugins/field-default/src/test/scala/com/stratio/sparkta/plugin/field/default/DefaultFieldTest.scala
@@ -31,9 +31,9 @@ class DefaultFieldTest extends WordSpecLike with Matchers {
 
   "A DefaultDimension" should {
     "In default implementation, get one precisions for a specific time" in {
-      val precision: (Precision, JSerializable) = defaultDimension.precisionValue("", "foo".asInstanceOf[JSerializable])
+      val precision: (Precision, JSerializable) = defaultDimension.precisionValue("", "1".asInstanceOf[JSerializable])
 
-      precision._2 should be("foo")
+      precision._2 should be(1)
 
       precision._1.id should be(DimensionType.IdentityName)
     }

--- a/plugins/operator-avg/src/main/scala/com/stratio/sparkta/plugin/operator/avg/AvgOperator.scala
+++ b/plugins/operator-avg/src/main/scala/com/stratio/sparkta/plugin/operator/avg/AvgOperator.scala
@@ -28,7 +28,7 @@ with ProcessMapAsNumber {
 
   override val writeOperation = WriteOp.Avg
 
-  override val castingFilterType = TypeOp.Number
+  override val defaultCastingFilterType = TypeOp.Number
 
   override def processReduce(values: Iterable[Option[Any]]): Option[Double] = {
     val distinctValues = getDistinctValues(values.flatten)

--- a/plugins/operator-count/src/main/scala/com/stratio/sparkta/plugin/operator/count/CountOperator.scala
+++ b/plugins/operator-count/src/main/scala/com/stratio/sparkta/plugin/operator/count/CountOperator.scala
@@ -33,7 +33,7 @@ class CountOperator(name: String, properties: Map[String, JSerializable])
 
   override val writeOperation = WriteOp.Inc
 
-  override val castingFilterType = TypeOp.Number
+  override val defaultCastingFilterType = TypeOp.Number
 
   override def processMap(inputFields: Map[String, JSerializable]): Option[Any] = {
     applyFilters(inputFields).flatMap(filteredFields => distinctFields match {

--- a/plugins/operator-count/src/test/scala/com.stratio.sparkta.plugin.operator.count/CountOperatorTest.scala
+++ b/plugins/operator-count/src/test/scala/com.stratio.sparkta.plugin.operator.count/CountOperatorTest.scala
@@ -66,6 +66,29 @@ class CountOperatorTest extends WordSpec with Matchers {
             "{\"field\":\"field2\", \"type\": \"<\", \"value\":\"2\"}]"
         }))
       inputFields6.processMap(Map("field1" -> 1, "field2" -> 2)) should be(None)
+
+      val inputFields7 = new CountOperator("count",
+        Map("filters" -> {
+          "[{\"field\":\"field1\", \"type\": \"<\", \"value\":\"2\", \"fieldType\":\"int\"}," +
+            "{\"field\":\"field2\", \"type\": \"<\", \"value\":\"2\", \"fieldType\":\"int\"}]"
+        }))
+      inputFields7.processMap(Map("field1" -> 1L, "field2" -> 2L)) should be(None)
+
+      val inputFields8 = new CountOperator("count",
+        Map("filters" -> "[{\"field\":\"field1\", \"type\": \"<\", \"value\":2, \"fieldType\":\"int\"}]"))
+      inputFields8.processMap(Map("field1" -> 1, "field2" -> 2)) should be(Some(CountOperator.One.toLong))
+
+      val inputFields9 = new CountOperator("count",
+        Map("filters" -> "[{\"field\":\"field1\", \"type\": \"<\", \"value\":2, \"fieldType\":\"int\"}]"))
+      inputFields9.processMap(Map("field1" -> 1L, "field2" -> 2L)) should be(Some(CountOperator.One.toLong))
+
+      val inputFields10 = new CountOperator("count",
+        Map("filters" -> "[{\"field\":\"field1\", \"type\": \"<\", \"value\":2, \"fieldType\":\"int\"}]"))
+      inputFields10.processMap(Map("field1" -> 1d, "field2" -> 2d)) should be(Some(CountOperator.One.toLong))
+
+      val inputFields11 = new CountOperator("count",
+        Map("filters" -> "[{\"field\":\"field1\", \"type\": \"<\", \"value\":2, \"fieldType\":\"int\"}]"))
+      inputFields11.processMap(Map("field1" -> "1", "field2" -> "2")) should be(Some(CountOperator.One.toLong))
     }
 
     "processReduce must be " in {

--- a/plugins/operator-entityCount/src/test/scala/com/stratio/sparkta/plugin/operator/entityCount/EntityCountOperatorTest.scala
+++ b/plugins/operator-entityCount/src/test/scala/com/stratio/sparkta/plugin/operator/entityCount/EntityCountOperatorTest.scala
@@ -76,7 +76,7 @@ class EntityCountOperatorTest extends WordSpec with Matchers {
       val inputFields2 = new EntityCountOperator("entityCount", Map("typeOp" -> "int"))
       val resultInput2 = Seq((Operator.OldValuesKey, Some(Map("hola" -> 1L, "holo" -> 1L))),
         (Operator.NewValuesKey, Some(Seq("hola"))))
-      inputFields2.associativity(resultInput2) should be(Some(Map("hola" -> 2L, "holo" -> 1L)))
+      inputFields2.associativity(resultInput2) should be(Some(0))
 
       val inputFields3 = new EntityCountOperator("entityCount", Map("typeOp" -> null))
       val resultInput3 = Seq((Operator.OldValuesKey, Some(Map("hola" -> 1L, "holo" -> 1L))))

--- a/plugins/operator-max/src/main/scala/com/stratio/sparkta/plugin/operator/max/MaxOperator.scala
+++ b/plugins/operator-max/src/main/scala/com/stratio/sparkta/plugin/operator/max/MaxOperator.scala
@@ -30,7 +30,7 @@ with ProcessMapAsNumber with Associative {
 
   override val writeOperation = WriteOp.Max
 
-  override val castingFilterType = TypeOp.Number
+  override val defaultCastingFilterType = TypeOp.Number
 
   override def processReduce(values: Iterable[Option[Any]]): Option[Double] = {
     Try(Option(getDistinctValues(values.flatten.map(_.asInstanceOf[Number].doubleValue())).max))

--- a/plugins/operator-median/src/main/scala/com/stratio/sparkta/plugin/operator/median/MedianOperator.scala
+++ b/plugins/operator-median/src/main/scala/com/stratio/sparkta/plugin/operator/median/MedianOperator.scala
@@ -31,7 +31,7 @@ with ProcessMapAsNumber {
 
   override val writeOperation = WriteOp.Median
 
-  override val castingFilterType = TypeOp.Number
+  override val defaultCastingFilterType = TypeOp.Number
 
   override def processReduce(values: Iterable[Option[Any]]): Option[Double] = {
     val valuesFiltered = getDistinctValues(values.flatten)

--- a/plugins/operator-min/src/main/scala/com/stratio/sparkta/plugin/operator/min/MinOperator.scala
+++ b/plugins/operator-min/src/main/scala/com/stratio/sparkta/plugin/operator/min/MinOperator.scala
@@ -30,7 +30,7 @@ with ProcessMapAsNumber with Associative {
 
   override val writeOperation = WriteOp.Min
 
-  override val castingFilterType = TypeOp.Number
+  override val defaultCastingFilterType = TypeOp.Number
 
   override def processReduce(values: Iterable[Option[Any]]): Option[Double] = {
     Try(Option(getDistinctValues(values.flatten.map(_.asInstanceOf[Number].doubleValue())).min))

--- a/plugins/operator-range/src/main/scala/com/stratio/sparkta/plugin/operator/range/RangeOperator.scala
+++ b/plugins/operator-range/src/main/scala/com/stratio/sparkta/plugin/operator/range/RangeOperator.scala
@@ -28,7 +28,7 @@ with ProcessMapAsNumber {
 
   override val writeOperation = WriteOp.Range
 
-  override val castingFilterType = TypeOp.Number
+  override val defaultCastingFilterType = TypeOp.Number
 
   override def processReduce(values: Iterable[Option[Any]]): Option[Double] = {
     val valuesFiltered = getDistinctValues(values.flatten)

--- a/plugins/operator-stddev/src/main/scala/com/stratio/sparkta/plugin/operator/stddev/StddevOperator.scala
+++ b/plugins/operator-stddev/src/main/scala/com/stratio/sparkta/plugin/operator/stddev/StddevOperator.scala
@@ -30,7 +30,7 @@ with ProcessMapAsNumber {
 
   override val writeOperation = WriteOp.Stddev
 
-  override val castingFilterType = TypeOp.Number
+  override val defaultCastingFilterType = TypeOp.Number
 
   override def processReduce(values: Iterable[Option[Any]]): Option[Double] = {
     val valuesFiltered = getDistinctValues(values.flatten)

--- a/plugins/operator-sum/src/main/scala/com/stratio/sparkta/plugin/operator/sum/SumOperator.scala
+++ b/plugins/operator-sum/src/main/scala/com/stratio/sparkta/plugin/operator/sum/SumOperator.scala
@@ -30,7 +30,7 @@ with ProcessMapAsNumber with Associative {
 
   override val writeOperation = WriteOp.Inc
 
-  override val castingFilterType = TypeOp.Number
+  override val defaultCastingFilterType = TypeOp.Number
 
   override def processReduce(values: Iterable[Option[Any]]): Option[Double] = {
     Try(Option(getDistinctValues(values.flatten.map(_.asInstanceOf[Number].doubleValue())).sum))

--- a/plugins/operator-variance/src/main/scala/com/stratio/sparkta/plugin/operator/variance/VarianceOperator.scala
+++ b/plugins/operator-variance/src/main/scala/com/stratio/sparkta/plugin/operator/variance/VarianceOperator.scala
@@ -30,7 +30,7 @@ with ProcessMapAsNumber {
 
   override val writeOperation = WriteOp.Variance
 
-  override val castingFilterType = TypeOp.Number
+  override val defaultCastingFilterType = TypeOp.Number
 
   override def processReduce(values: Iterable[Option[Any]]): Option[Double] = {
     val valuesFiltered = getDistinctValues(values.flatten)

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/FilterModel.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/FilterModel.scala
@@ -18,5 +18,6 @@ package com.stratio.sparkta.sdk
 
 case class FilterModel(field: String,
                        `type`: String,
-                       value : Option[String],
-                       fieldValue: Option[String])
+                       value: Option[String],
+                       fieldValue: Option[String],
+                       fieldType: Option[String] = None)

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/TypeOp.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/TypeOp.scala
@@ -29,6 +29,7 @@ object TypeOp extends Enumeration {
   ArrayString, MapStringLong = Value
 
   final val TypeOperationsNames = Map(
+    "number" -> TypeOp.Number,
     "bigdecimal" -> TypeOp.BigDecimal,
     "long" -> TypeOp.Long,
     "int" -> TypeOp.Int,
@@ -44,9 +45,12 @@ object TypeOp extends Enumeration {
     "mapstringlong" -> TypeOp.MapStringLong
   )
 
+  //scalastyle:off
   def transformValueByTypeOp[T](typeOp: TypeOp, origValue: T): T = {
     typeOp match {
       case TypeOp.String => checkStringType(origValue)
+      case TypeOp.Double | TypeOp.Number => checkDoubleType(origValue)
+      case TypeOp.Int => checkIntType(origValue)
       case TypeOp.ArrayDouble => checkArrayDoubleType(origValue)
       case TypeOp.ArrayString => checkArrayStringType(origValue)
       case TypeOp.Timestamp => checkTimestampType(origValue)
@@ -57,6 +61,8 @@ object TypeOp extends Enumeration {
       case _ => origValue
     }
   }
+
+  //scalastyle:on
 
   private def checkStringType[T](origValue : T) : T = origValue match {
     case value if value.isInstanceOf[String] => value
@@ -116,7 +122,23 @@ object TypeOp extends Enumeration {
 
   private def checkLongType[T](origValue : T) : T = origValue match {
     case value if value.isInstanceOf[Long] => value
+    case value if value.isInstanceOf[Double] => Try(origValue.asInstanceOf[Double].toLong).getOrElse(0).asInstanceOf[T]
+    case value if value.isInstanceOf[Int] => Try(origValue.asInstanceOf[Int].toLong).getOrElse(0).asInstanceOf[T]
     case _ => Try(origValue.toString.toLong).getOrElse(0L).asInstanceOf[T]
+  }
+
+  private def checkDoubleType[T](origValue : T) : T = origValue match {
+    case value if value.isInstanceOf[Double] => value
+    case value if value.isInstanceOf[Int] => Try(origValue.asInstanceOf[Int].toDouble).getOrElse(0).asInstanceOf[T]
+    case value if value.isInstanceOf[Long] => Try(origValue.asInstanceOf[Long].toDouble).getOrElse(0).asInstanceOf[T]
+    case _ => Try(origValue.toString.toDouble).getOrElse(0d).asInstanceOf[T]
+  }
+
+  private def checkIntType[T](origValue : T) : T = origValue match {
+    case value if value.isInstanceOf[Int] => value
+    case value if value.isInstanceOf[Double] => Try(origValue.asInstanceOf[Double].toInt).getOrElse(0).asInstanceOf[T]
+    case value if value.isInstanceOf[Long] => Try(origValue.asInstanceOf[Long].toInt).getOrElse(0).asInstanceOf[T]
+    case _ => Try(origValue.toString.toInt).getOrElse(0).asInstanceOf[T]
   }
 
   def getTypeOperationByName(nameOperation: String, defaultTypeOperation: TypeOp): TypeOp =

--- a/sdk/src/test/scala/com/stratio/sparkta/sdk/OperatorTest.scala
+++ b/sdk/src/test/scala/com/stratio/sparkta/sdk/OperatorTest.scala
@@ -242,7 +242,7 @@ class OperatorTest extends WordSpec with Matchers {
     "Operation casting filter must be " in {
       val operator = new OperatorMock("opTest", Map())
       val expected = TypeOp.Number
-      val result = operator.castingFilterType
+      val result = operator.defaultCastingFilterType
       result should be(expected)
     }
 

--- a/sdk/src/test/scala/com/stratio/sparkta/sdk/test/OperatorMock.scala
+++ b/sdk/src/test/scala/com/stratio/sparkta/sdk/test/OperatorMock.scala
@@ -33,11 +33,11 @@ abstract class BaseOperatorMoc(name: String, properties: Map[String, JSerializab
 class OperatorMock(name: String, properties: Map[String, JSerializable])
   extends BaseOperatorMoc(name: String, properties: Map[String, JSerializable]) with ProcessMapAsNumber {
 
-  override val castingFilterType = TypeOp.Number
+  override val defaultCastingFilterType = TypeOp.Number
 }
 
 class OperatorMockString(name: String, properties: Map[String, JSerializable])
   extends BaseOperatorMoc(name: String, properties: Map[String, JSerializable]) with ProcessMapAsAny {
 
-  override val castingFilterType = TypeOp.String
+  override val defaultCastingFilterType = TypeOp.String
 }


### PR DESCRIPTION
#### Description

* Now in the filters we can select the type of the field value. If you not select anything sparkta use the default in the operator.

* Bug in TypeOperation are corrected, added more types conversions.


#### Reviewer
@anistal 
