### PR TITLE
[SPARKTA-109] New parser used in Stratio Ingestion

### DIFF
--- a/plugins/parser-ingestion/pom.xml
+++ b/plugins/parser-ingestion/pom.xml
@@ -1,0 +1,29 @@
+
+<!--
+
+    Copyright (C) 2014 Stratio (http://stratio.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>plugins</artifactId>
+        <groupId>com.stratio.sparkta</groupId>
+        <version>0.8.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>parser-ingestion</artifactId>
+</project>

--- a/plugins/parser-ingestion/src/main/scala/com/stratio/sparkta/plugin/parser/ingestion/IngestionParser.scala
+++ b/plugins/parser-ingestion/src/main/scala/com/stratio/sparkta/plugin/parser/ingestion/IngestionParser.scala
@@ -1,0 +1,111 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparkta.plugin.parser.ingestion
+
+import java.io.{Serializable => JSerializable}
+
+import com.stratio.sparkta.sdk.{Event, Parser}
+import org.joda.time.DateTime
+import org.joda.time.format.DateTimeFormat
+
+import scala.annotation.tailrec
+import scala.util.parsing.json.JSON
+
+class IngestionParser(name: String,
+                      order: Integer,
+                      inputField: String,
+                      outputFields: Seq[String],
+                      properties: Map[String, JSerializable])
+  extends Parser(name, order, inputField, outputFields, properties) {
+
+  private val DatetimePattern = "yyyy-MM-dd HH:mm:ss"
+
+  override def parse(data: Event): Event = {
+    val ingestionModel = JSON.parseFull(data.keyMap.get(inputField).get.asInstanceOf[String])
+      .get.asInstanceOf[Map[String,JSerializable]]
+    val columnList = ingestionModel.get("columns").get.asInstanceOf[List[Map[String, String]]]
+    val columnPairs = extractColumnPairs(columnList)
+    val allParsedPairs = parseWithSchema(columnPairs, Map())._2
+    val filteredParsedPairs = allParsedPairs.filter(element => outputFields.contains(element._1))
+    new Event(filteredParsedPairs)
+  }
+
+  // XXX Private methods.
+
+  private def extractColumnPairs(columnList: List[Map[String, String]]): List[(String, String)] = {
+    val columnListKeyValue = for {
+      columnElement <- columnList
+      value <- columnElement
+    } yield Map(value._1 -> value._2)
+    extractColumnPairElement(columnListKeyValue, List())._2
+  }
+
+  @tailrec
+  private def extractColumnPairElement(columnList: List[Map[String, String]],
+                                       result: List[(String,String)])
+  : (List[Map[String,String]], List[(String,String)]) = {
+    if(columnList.isEmpty) {
+      (columnList, result)
+    } else {
+      val currentValue = columnList.last.head._2
+      val columnListWithoutValue = columnList.init
+      val currentKey = columnListWithoutValue.last.head._2
+      val columnListWithoutKeyAndValue = columnListWithoutValue.init
+      extractColumnPairElement(columnListWithoutKeyAndValue, result.:::(List((currentKey, currentValue))))
+    }
+  }
+
+  @tailrec
+  private def parseWithSchema(elementList: List[(String, String)],
+                              currentMap: Map[String,JSerializable])
+  : (List[(String, JSerializable)],Map[String,JSerializable]) = {
+    if(elementList.isEmpty) {
+      (elementList, currentMap)
+    } else {
+      val currentElement = elementList.last
+      val newElementList = elementList.init
+      val newCurrentMap = currentMap ++ parseElementWithSchema(currentElement)
+      parseWithSchema(newElementList, newCurrentMap)
+    }
+  }
+
+  private def parseElementWithSchema(element: (String, JSerializable)): Map[String, JSerializable] = {
+    val key = element._1
+    val value = element._2.toString
+
+    val dataType: Option[String] = (properties.get(key) match {
+      case Some(value) => Some(value.toString.toLowerCase)
+      case _ => None
+    })
+
+    dataType match {
+      case Some("long") =>
+        Map(key -> value.toLong)
+      case Some("int") | Some("integer") =>
+        Map(key -> value.toInt)
+      case Some("string") =>
+        Map(key -> value)
+      case Some("float") =>
+        Map(key -> value.toFloat)
+      case Some("double") =>
+        Map(key -> value.toDouble)
+      case None =>
+        Map()
+      case _ => throw new NoSuchElementException(s"The dataType $dataType does not exists in the schema.")
+    }
+  }
+}

--- a/plugins/parser-ingestion/src/test/resources/log4j.xml
+++ b/plugins/parser-ingestion/src/test/resources/log4j.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright (C) 2014 Stratio (http://stratio.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+    <appender name="console" class="org.apache.log4j.ConsoleAppender">
+        <param name="Target" value="System.out"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%-5p %c{1} - %m%n"/>
+        </layout>
+    </appender>
+
+    <root>
+        <priority value="debug"/>
+        <appender-ref ref="console"/>
+    </root>
+
+</log4j:configuration>

--- a/plugins/parser-ingestion/src/test/scala/com/stratio/sparkta/plugin/parser/ingestion/IngestionParserTest.scala
+++ b/plugins/parser-ingestion/src/test/scala/com/stratio/sparkta/plugin/parser/ingestion/IngestionParserTest.scala
@@ -1,0 +1,165 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparkta.plugin.parser.ingestion
+
+import com.stratio.sparkta.sdk.{Event, Input}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, Matchers, WordSpecLike}
+
+@RunWith(classOf[JUnitRunner])
+class IngestionParserTest extends WordSpecLike with Matchers with BeforeAndAfter with BeforeAndAfterAll {
+
+  val ParserName = "IngestionParser"
+  val ParserOrder = 1
+  val InputField = Input.RawDataKey
+  val OutputsFields = Seq("ColumnA", "ColumnB", "ColumnC", "ColumnD", "ColumnE", "ColumnF")
+  val ParserConfig = Map(
+    "ColumnA" -> "string",
+    "ColumnB" -> "long",
+    "ColumnC" -> "integer",
+    "ColumnD" -> "float",
+    "ColumnE" -> "double",
+    "ColumnF" -> "datetime"
+  )
+
+  "A IngestionParser" should {
+    "parse an event with an input that has the same columns that the schema specified in the config" in {
+      val expectedEvent = Event(Map(
+        "ColumnA" -> "columnAValue",
+        "ColumnB" -> 1L,
+        "ColumnC" -> 1,
+        "ColumnD" -> 1F,
+        "ColumnE" -> 1D
+      ))
+
+      val json =
+        """
+          |{
+          |   "columns":[
+          |      {
+          |         "column":"ColumnA",
+          |         "value":"columnAValue"
+          |      },
+          |      {
+          |         "column":"ColumnB",
+          |         "value":"1"
+          |      },
+          |      {
+          |         "column":"ColumnC",
+          |         "value":"1"
+          |      },
+          |      {
+          |         "column":"ColumnD",
+          |         "value":"1"
+          |      },
+          |      {
+          |         "column":"ColumnE",
+          |         "value":"1"
+          |      }
+          |   ]
+          |}
+          |""".stripMargin
+
+      val inputEvent = Event(Map(InputField -> json),None)
+      val ingestionParser = new IngestionParser(ParserName, ParserOrder, InputField, OutputsFields, ParserConfig)
+      val event = ingestionParser.parse(inputEvent)
+
+      event should be eq(expectedEvent)
+    }
+
+    "parse an event with an input that has different number of columns that the schema specified in the config" in {
+      val expectedEvent = Event(Map(
+        "ColumnA" -> "columnAValue",
+        "ColumnB" -> 1L
+      ))
+
+      val json =
+        """
+          |{
+          |   "columns":[
+          |      {
+          |         "column":"ColumnA",
+          |         "value":"columnAValue"
+          |      },
+          |      {
+          |         "column":"ColumnB",
+          |         "value":"1"
+          |      }
+          |   ]
+          |}
+          |""".stripMargin
+
+      val inputEvent = Event(Map(InputField -> json),None)
+      val ingestionParser = new IngestionParser(ParserName, ParserOrder, InputField, OutputsFields, ParserConfig)
+      val event = ingestionParser.parse(inputEvent)
+
+      event should be eq(expectedEvent)
+    }
+
+    "parse an event with an input that has different number of columns that the schema specified in the config and " +
+      "one of the column is not defined in the schema" in {
+      val expectedEvent = Event(Map(
+        "ColumnA" -> "columnAValue",
+        "ColumnB" -> 1L
+      ))
+      val json =
+        """
+          |{
+          |   "columns":[
+          |      {
+          |         "column":"ColumnA",
+          |         "value":"columnAValue"
+          |      },
+          |      {
+          |         "column":"ColumnNotDefined",
+          |         "value":"1"
+          |      }
+          |   ]
+          |}
+          |""".stripMargin
+
+      val inputEvent = Event(Map(InputField -> json),None)
+      val ingestionParser = new IngestionParser(ParserName, ParserOrder, InputField, OutputsFields, ParserConfig)
+      val event = ingestionParser.parse(inputEvent)
+
+      event should be eq(expectedEvent)
+    }
+
+    "throws an exception when a element is defined in the schema, but the type do not exists" in {
+      val WrongParserConfig = Map(
+        "ColumnA" -> "intugur")
+
+      val json =
+        """
+          |{
+          |   "columns":[
+          |      {
+          |         "column":"ColumnA",
+          |         "value":"columnAValue"
+          |      }
+          |   ]
+          |}
+          |""".stripMargin
+
+      val inputEvent = Event(Map(InputField -> json),None)
+      val ingestionParser = new IngestionParser(ParserName, ParserOrder, InputField, OutputsFields, WrongParserConfig)
+
+      an[NoSuchElementException] should  be thrownBy(ingestionParser.parse(inputEvent))
+    }
+  }
+}

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -67,6 +67,7 @@
         <module>parser-morphlines</module>
         <module>input-rabbitMQ</module>
         <module>parser-type</module>
+        <module>parser-ingestion</module>
     </modules>
 
     <dependencies>

--- a/serving-core/src/main/scala/com/stratio/sparkta/serving/core/constants/AppConstant.scala
+++ b/serving-core/src/main/scala/com/stratio/sparkta/serving/core/constants/AppConstant.scala
@@ -129,6 +129,7 @@ object AppConstant {
     "Redis" -> s"output-redis$pluginExtension",
     s"DateTime${Parser.ClassSuffix}" -> s"parser-datetime$pluginExtension",
     s"Morphlines${Parser.ClassSuffix}" -> s"parser-morphlines$pluginExtension",
+    s"Ingestion${Parser.ClassSuffix}" -> s"parser-ingestion$pluginExtension",
     s"Type${Parser.ClassSuffix}" -> s"parser-type$pluginExtension"
   )
 }


### PR DESCRIPTION
#### Description
This new parser is used to compute events generated by Stratio Ingestion.
Stratio Ingestion sends a JSON with a field "columns" that contains a list of elements that Sparkta will be use to extract dimensions.
Example:

    {
        "columns": [
            {
                "column": "ColumnA",
                "value": "ColumnAValue"
            }
        ]
    }

The main idea is to have an schema in the Ingestion Parser's configuration to build the event.
Example:

    "configuration": {
        "ColumnA": "string"
    }
   
#### Test & Coverage
Created 1 test with a 100% of coverage over the IngestionParser.
