### PR TITLE
SPARKTA-263 Default application.conf values are wrong

### DIFF
--- a/dist/src/main/resources/application.conf
+++ b/dist/src/main/resources/application.conf
@@ -13,17 +13,16 @@ sparkta {
   config {
     executionMode = local
     rememberPartitioner = true
-    topGracefully = true
+    stopGracefully = true
   }
 
   local {
     spark.app.name = SPARKTA
-    spark.master = "local[4]"
-    spark.cores.max = 4
+    spark.master = "local[*]"
     spark.executor.memory = 1024m
     spark.app.name = SPARKTA
     spark.sql.parquet.binaryAsString = true
-    spark.streaming.concurrentJobs = 10
+    spark.streaming.concurrentJobs = 1
   }
 
   hdfs {
@@ -41,7 +40,7 @@ sparkta {
     numExecutors = 2
     masterDispatchers = 127.0.0.1
     spark.app.name = SPARKTA
-    spark.streaming.concurrentJobs = 10
+    spark.streaming.concurrentJobs = 1
     spark.cores.max = 2
     spark.mesos.extra.cores = 1
     spark.mesos.coarse = true

--- a/serving-api/src/main/resources/reference.conf
+++ b/serving-api/src/main/resources/reference.conf
@@ -31,7 +31,7 @@ sparkta {
     spark.executor.memory = 1024m
     spark.app.name = SPARKTA
     spark.sql.parquet.binaryAsString = true
-    spark.streaming.concurrentJobs = 10
+    spark.streaming.concurrentJobs = 1
   }
 
   hdfs {
@@ -48,7 +48,7 @@ sparkta {
     deployMode = cluster
     numExecutors = 2
     masterDispatchers = 127.0.0.1
-    spark.streaming.concurrentJobs = 20
+    spark.streaming.concurrentJobs = 1
     spark.cores.max = 4
     spark.mesos.extra.cores = 1
     spark.mesos.coarse = true


### PR DESCRIPTION
#### Description

This property should have the following value for taking the cores depending on the machine:
spark.master = "local[*]"

#### Reviewer
@anistal 

#### Test
All passed.

#### Coverage
No changes

#### Scalastyle
No info