### PR TITLE
SPARKTA-217 [WEB] Set default property value to Cassandra output

### DIFF
--- a/examples/policies/ITwitterJson-OCassandra.json
+++ b/examples/policies/ITwitterJson-OCassandra.json
@@ -92,7 +92,13 @@
         "connectionHost": "127.0.0.1",
         "connectionPort": "9042",
         "cluster": "Test Cluster",
-        "keyspace": "sparkta"
+        "keyspace": "sparkta",
+        "sparkProperties": [
+          {
+            "sparkPropertyKey": "spark.cassandra.connection.keep_alive_ms",
+            "sparkPropertyValue": "180000"
+          }
+        ]
       }
     }
   ]

--- a/examples/policies/fragments/CassandraFragment.json
+++ b/examples/policies/fragments/CassandraFragment.json
@@ -9,7 +9,13 @@
     "configuration": {
       "connectionHost": "127.0.0.1",
       "cluster": "Test Cluster",
-      "keyspace": "sparkta"
+      "keyspace": "sparkta",
+      "sparkProperties": [
+        {
+          "sparkPropertyKey": "spark.cassandra.connection.keep_alive_ms",
+          "sparkPropertyValue": "180000"
+        }
+      ]
     }
   }
 }

--- a/test-at/src/test/resources/policies/ISocket-OCassandra-operators.json
+++ b/test-at/src/test/resources/policies/ISocket-OCassandra-operators.json
@@ -189,7 +189,13 @@
         "connectionHost": "127.0.0.1",
         "connectionPort": "9142",
         "cluster": "Test Cluster",
-        "keyspace": "sparkta"
+        "keyspace": "sparkta",
+        "sparkProperties": [
+          {
+            "sparkPropertyKey": "spark.cassandra.connection.keep_alive_ms",
+            "sparkPropertyValue": "180000"
+          }
+        ]
       }
     }
   ]

--- a/test-at/src/test/resources/policies/ISocket-OCassandra.json
+++ b/test-at/src/test/resources/policies/ISocket-OCassandra.json
@@ -103,7 +103,13 @@
         "connectionHost": "127.0.0.1",
         "connectionPort": "9142",
         "cluster": "Test Cluster",
-        "keyspace": "sparkta"
+        "keyspace": "sparkta",
+        "sparkProperties": [
+          {
+            "sparkPropertyKey": "spark.cassandra.connection.keep_alive_ms",
+            "sparkPropertyValue": "180000"
+          }
+        ]
       }
     }
   ]

--- a/web/src/data-templates/output.json
+++ b/web/src/data-templates/output.json
@@ -175,20 +175,20 @@
             "propertyName": "_SPARK_PROPERTY_KEY_",
             "propertyType": "text",
             "regexp": "",
-            "default": "spark.cassandra.input.fetch.size_in_rows",
+            "default": "spark.cassandra.connection.keep_alive_ms",
             "hidden": false,
             "required": false,
-            "qa": "fragment-details-mongoDb-sparkPropertyKey"
+            "qa": "fragment-details-cassandra-sparkPropertyKey"
           },
           {
             "propertyId": "sparkPropertyValue",
             "propertyName": "_SPARK_PROPERTY_VALUE_",
             "propertyType": "text",
             "regexp": "",
-            "default": "1000",
+            "default": "180000",
             "hidden": false,
             "required": true,
-            "qa": "fragment-details-mongoDb-sparkPropertyValue"
+            "qa": "fragment-details-cassandra-sparkPropertyValue"
           }
         ]
       }


### PR DESCRIPTION
Setting the value for this property to 2 seconds. By default it is in 250 milliseconds which makes the output create a new Cassandra connection in every DStream.

This PR will allow the Cassandra output to reuse a connection.