### PR TITLE
SPARKTA-285 Generic way to define the granularity

### DIFF
--- a/plugins/field-dateTime/src/main/scala/com/stratio/sparkta/plugin/field/datetime/DateTimeField.scala
+++ b/plugins/field-dateTime/src/main/scala/com/stratio/sparkta/plugin/field/datetime/DateTimeField.scala
@@ -69,9 +69,9 @@ object DateTimeField {
   final val DayName = "day"
   final val MonthName = "month"
   final val YearName = "year"
-  final val s15Name = "s15"
-  final val s10Name = "s10"
-  final val s5Name = "s5"
+  final val s15Name = "15s"
+  final val s10Name = "10s"
+  final val s5Name = "5s"
   final val Precisions = Seq(SecondName, MinuteName, HourName, DayName, MonthName, YearName, s15Name, s10Name, s5Name)
   final val timestamp = DimensionType.getTimestamp(Some(TypeOp.Timestamp), TypeOp.Timestamp)
 

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/AggregationTime.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/AggregationTime.scala
@@ -1,0 +1,84 @@
+/**
+  * Copyright (C) 2015 Stratio (http://stratio.com)
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package com.stratio.sparkta.sdk
+
+import com.github.nscala_time.time.Imports._
+import org.joda.time.Duration
+
+import scala.util.matching.Regex
+
+object AggregationTime {
+  val Prefix: Seq[String] = Seq(
+    "[1-9][0-9]*s","[1-9][0-9]*m","[1-9][0-9]*h", "[1-9][0-9]*d", "second", "minute", "hour", "day", "month", "year")
+
+  def truncateDate(date: DateTime, granularity: String): Long = {
+
+    val duration: Duration = parseDate(date, granularity)
+    roundDateTime(date, duration)
+  }
+
+  def parseDate(date: DateTime, aggregationTime: String): Duration = {
+    val prefix = for {
+      prefix <- Prefix
+      if(aggregationTime.matches(prefix))
+    } yield (prefix)
+  selectGranularity(prefix, aggregationTime, date)
+  }
+
+  def selectGranularity(prefix: Seq[String], aggregationTime: String, date: DateTime): Duration = {
+    if(prefix.headOption.isDefined) {
+      prefix(0) match {
+        case "[1-9][0-9]*s" =>
+          Duration.standardSeconds(aggregationTime.replace("s","").toLong)
+        case "[1-9][0-9]*m" =>
+          Duration.standardMinutes(aggregationTime.replace("m","").toLong)
+        case "[1-9][0-9]*h" =>
+          Duration.standardHours(aggregationTime.replace("h","").toLong)
+        case "[1-9][0-9]*d" =>
+          Duration.standardDays(aggregationTime.replace("d","").toLong)
+        case _ =>
+          genericDates(date, aggregationTime)
+      }
+    } else {
+      throw new IllegalArgumentException("The value for the granularity is not valid")
+    }
+  }
+
+  def genericDates(date: DateTime, granularity: String): Duration = {
+
+    val secondsDate = date.withMillisOfSecond(0)
+    val minutesDate = secondsDate.withSecondOfMinute(0)
+    val hourDate = minutesDate.withMinuteOfHour(0)
+    val dayDate = hourDate.withHourOfDay(0)
+    val monthDate = dayDate.withDayOfMonth(1)
+    val yearDate = monthDate.withMonthOfYear(1)
+
+    granularity.toLowerCase match {
+      case "second" => Duration.millis(secondsDate.getMillis)
+      case "minute" => Duration.millis(minutesDate.getMillis)
+      case "hour" => Duration.millis(hourDate.getMillis)
+      case "day" => Duration.millis(dayDate.getMillis)
+      case "month" => Duration.millis(monthDate.getMillis)
+      case "year" => Duration.millis(yearDate.getMillis)
+      case _ => throw new IllegalArgumentException("The value for the granularity is not valid")
+    }
+  }
+
+  def roundDateTime(t: DateTime, d: Duration): Long =
+    (t minus (t.getMillis - (t.getMillis.toDouble / d.getMillis).round * d.getMillis)).getMillis
+}
+

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/DateOperations.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/DateOperations.scala
@@ -30,32 +30,12 @@ object DateOperations {
       case _ => 0L
     }
 
-  def dateFromGranularity(value: DateTime, granularity: String): Long = {
-    val secondsDate = value.withMillisOfSecond(0)
-    val minutesDate = secondsDate.withSecondOfMinute(0)
-    val hourDate = minutesDate.withMinuteOfHour(0)
-    val dayDate = hourDate.withHourOfDay(0)
-    val monthDate = dayDate.withDayOfMonth(1)
-    val yearDate = monthDate.withMonthOfYear(1)
-    val s15 = roundDateTime(value, Duration.standardSeconds(15))
-    val s10 = roundDateTime(value, Duration.standardSeconds(10))
-    val s5 = roundDateTime(value, Duration.standardSeconds(5))
-
-    granularity.toLowerCase match {
-      case "minute" => minutesDate.getMillis
-      case "hour" => hourDate.getMillis
-      case "day" => dayDate.getMillis
-      case "month" => monthDate.getMillis
-      case "year" => yearDate.getMillis
-      case "second" => secondsDate.getMillis
-      case "s15" => s15.getMillis
-      case "s10" => s10.getMillis
-      case "s5" => s5.getMillis
-      case _ => 0L
-    }
+  def dateFromGranularity(date: DateTime, granularity: String): Long = {
+    AggregationTime.truncateDate(date, granularity)
   }
 
   def millisToTimeStamp(date: Long): Timestamp = new Timestamp(date)
+
 
   def getMillisFromSerializable(date: JSerializable): Long = date match {
     case value if value.isInstanceOf[Timestamp] || value.isInstanceOf[Date]

--- a/sdk/src/test/scala/com/stratio/sparkta/sdk/DateOperationsTest.scala
+++ b/sdk/src/test/scala/com/stratio/sparkta/sdk/DateOperationsTest.scala
@@ -21,6 +21,7 @@ import java.sql.Timestamp
 import java.util.Date
 
 import com.github.nscala_time.time.Imports._
+import com.stratio.sparkta.sdk.DateOperations
 import org.joda.time.DateTime
 import org.junit.runner.RunWith
 import org.scalatest._
@@ -86,37 +87,38 @@ class DateOperationsTest extends FlatSpec with ShouldMatchers {
     val hourPatternResult = DateTimeFormat.forPattern(hourPattern).print(DateTime.now())
     val minutePatternResult = DateTimeFormat.forPattern(minutePattern).print(DateTime.now())
     val defaultPatternResult = DateTimeFormat.forPattern(defaultPattern).print(DateTime.now())
+
   }
 
   "DateOperations" should "return timestamp with correct parameters" in new CommonValues {
-    DateOperations.getTimeFromGranularity(Some(""), Some("s5")) should not be (wrongDT)
-    DateOperations.getTimeFromGranularity(Some(""), Some("s10")) should not be (wrongDT)
-    DateOperations.getTimeFromGranularity(Some(""), Some("s15")) should not be (wrongDT)
+    DateOperations.getTimeFromGranularity(Some(""), Some("5s")) should not be (wrongDT)
+    DateOperations.getTimeFromGranularity(Some(""), Some("10s")) should not be (wrongDT)
+    DateOperations.getTimeFromGranularity(Some(""), Some("15s")) should not be (wrongDT)
     DateOperations.getTimeFromGranularity(Some(""), Some("minute")) should not be (wrongDT)
     DateOperations.getTimeFromGranularity(Some(""), Some("hour")) should not be (wrongDT)
     DateOperations.getTimeFromGranularity(Some(""), Some("day")) should not be (wrongDT)
     DateOperations.getTimeFromGranularity(Some(""), Some("month")) should not be (wrongDT)
     DateOperations.getTimeFromGranularity(Some(""), Some("year")) should not be (wrongDT)
     DateOperations.getTimeFromGranularity(Some("asdasd"), Some("year")) should not be (wrongDT)
-    DateOperations.getTimeFromGranularity(Some(""), Some("bad")) should be(wrongDT)
+    an[IllegalArgumentException] should be thrownBy DateOperations.getTimeFromGranularity(Some(""), Some("bad"))
   }
 
   it should "return parsed timestamp with granularity" in new CommonValues {
-    DateOperations.dateFromGranularity(dt, "s5") should be(s5DT.getMillis)
-    DateOperations.dateFromGranularity(dt, "s15") should be(s15DT.getMillis)
-    DateOperations.dateFromGranularity(dt, "s10") should be(s10DT.getMillis)
+    DateOperations.dateFromGranularity(dt, "5s") should be(s5DT.getMillis)
+    DateOperations.dateFromGranularity(dt, "15s") should be(s15DT.getMillis)
+    DateOperations.dateFromGranularity(dt, "10s") should be(s10DT.getMillis)
     DateOperations.dateFromGranularity(dt, "minute") should be(minuteDT.getMillis)
     DateOperations.dateFromGranularity(dt, "hour") should be(hourDT.getMillis)
     DateOperations.dateFromGranularity(dt, "day") should be(dayDT.getMillis)
     DateOperations.dateFromGranularity(dt, "month") should be(monthDT.getMillis)
     DateOperations.dateFromGranularity(dt, "year") should be(yearDT.getMillis)
-    DateOperations.dateFromGranularity(dt, "bad") should be(wrongDT)
+    an[IllegalArgumentException] should be thrownBy DateOperations.dateFromGranularity(dt, "bad")
   }
 
   it should "format path ignoring pattern" in new FailValues {
-    DateOperations.subPath(badGranularity, datePattern) should be(expectedPath)
-    DateOperations.subPath(badGranularity, datePattern) should be(expectedPath)
-    DateOperations.subPath(badGranularity, emptyPattern) should be(expectedPath)
+    an[IllegalArgumentException] should be thrownBy  DateOperations.subPath(badGranularity, datePattern)
+    an[IllegalArgumentException] should be thrownBy  DateOperations.subPath(badGranularity, datePattern)
+    an[IllegalArgumentException] should be thrownBy  DateOperations.subPath(badGranularity, emptyPattern)
     DateOperations.subPath(granularity, emptyPattern) should be(expectedGranularityPath)
     DateOperations.subPath(granularity, datePattern) should be(expectedGranularityWithPattern)
   }
@@ -124,17 +126,17 @@ class DateOperationsTest extends FlatSpec with ShouldMatchers {
   it should "round to 15 seconds" in new CommonValues {
     val formatter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.ZZZ")
     val now = formatter.parseDateTime("1984-03-17 13:13:17.CET")
-    DateOperations.dateFromGranularity(now, "s15") should be(448373595000L)
+    DateOperations.dateFromGranularity(now, "15s") should be(448373595000L)
   }
   it should "round to 10 seconds" in new CommonValues {
     val formatter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.ZZZ")
     val now = formatter.parseDateTime("1984-03-17 13:13:17.CET")
-    DateOperations.dateFromGranularity(now, "s10") should be(448373600000L)
+    DateOperations.dateFromGranularity(now, "10s") should be(448373600000L)
   }
   it should "round to 5 seconds" in new CommonValues {
     val formatter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.ZZZ")
     val now = formatter.parseDateTime("1984-03-17 13:13:17.CET")
-    DateOperations.dateFromGranularity(now, "s5") should be(448373595000L)
+    DateOperations.dateFromGranularity(now, "5s") should be(448373595000L)
   }
 
   it should "return millis from a Serializable date" in new CommonValues {

--- a/sdk/src/test/scala/com/stratio/sparkta/sdk/test/AggregationTimeTest.scala
+++ b/sdk/src/test/scala/com/stratio/sparkta/sdk/test/AggregationTimeTest.scala
@@ -1,0 +1,82 @@
+/**
+  * Copyright (C) 2015 Stratio (http://stratio.com)
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package com.stratio.sparkta.sdk.test
+
+import com.github.nscala_time.time.Imports._
+import com.stratio.sparkta.sdk.AggregationTime
+import org.scalatest._
+
+
+class AggregationTimeTest extends FlatSpec with ShouldMatchers {
+  val formatter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.ZZZ")
+  val date = formatter.parseDateTime("2016-01-19 14:49:19.CET")
+
+  "AggregationTime" should "return the date in millis rounded to 15s" in {
+
+    val result = AggregationTime.truncateDate(date,"15s")
+    result should be(1453211355000L)
+  }
+
+  "AggregationTime" should "return the date in millis rounded to 15m" in {
+
+    val result = AggregationTime.truncateDate(date,"15m")
+    result should be(1453211100000L)
+  }
+
+  "AggregationTime" should "return the date in millis rounded to 15h" in {
+
+    val result = AggregationTime.truncateDate(date,"15h")
+    result should be(1453194000000L)
+  }
+
+  "AggregationTime" should "return the date in millis rounded to 15d" in {
+
+    val result = AggregationTime.truncateDate(date,"15d")
+    result should be(1452816000000L)
+  }
+
+  "AggregationTime" should "return the date in millis rounded to seconds" in {
+
+    val result = AggregationTime.truncateDate(date,"second")
+    result should be(1453211359000L)
+  }
+
+  "AggregationTime" should "return the date in millis rounded to minutes" in {
+
+    val result = AggregationTime.truncateDate(date,"minute")
+    result should be(1453211340000L)
+  }
+
+  "AggregationTime" should "return the date in millis rounded to hours" in {
+
+    val result = AggregationTime.truncateDate(date,"hour")
+    result should be(1453208400000L)
+  }
+
+  "AggregationTime" should "return the date in millis rounded to days" in {
+
+    val result = AggregationTime.truncateDate(date,"day")
+    result should be(1453158000000L)
+  }
+
+  "AggregationTime" should "return the date in millis rounded to year" in {
+
+    val result = AggregationTime.truncateDate(date,"year")
+    result should be(1451602800000L)
+  }
+
+}


### PR DESCRIPTION
Custom granularity to aggregate data added.
Now Sparkta is able to aggregate by any time, you can customize it with the followings unit of time:
- Seconds e.g 15s, 20s, etc
- Minutes e.g 15m, 20m, etc
- Hours e.g 15h, 20h, etc
- Days e.g 15d, 20d, etc

And also you can still aggregating the data like before.

Examples:
- By minute
```
  "cubes": [
    {
      "name": "testCube",
      "checkpointConfig": {
        "timeDimension": "minute",
        "granularity": "minute",
        "interval": 30000,
        "timeAvailability": 60000
      }
```
- By 15 seconds
```
  "cubes": [
    {
      "name": "testCube",
      "checkpointConfig": {
        "timeDimension": "minute",
        "granularity": "15s",
        "interval": 30000,
        "timeAvailability": 60000
      }
```
- By 30 minutes
```
  "cubes": [
    {
      "name": "testCube",
      "checkpointConfig": {
        "timeDimension": "minute",
        "granularity": "30m",
        "interval": 30000,
        "timeAvailability": 60000
      }
```