### PR TITLE
[SPARKTA-255] No-time-dependant aggregations

### DIFF
--- a/aggregator/src/test/scala/com/stratio/sparkta/aggregator/CubeMakerTest.scala
+++ b/aggregator/src/test/scala/com/stratio/sparkta/aggregator/CubeMakerTest.scala
@@ -72,11 +72,8 @@ class CubeMakerTest extends TestSuiteBase {
     val cube = Cube(name,
       Seq(dimension, timeDimension),
       Seq(operator),
-      checkpointGranularity,
-      checkpointInterval,
-      checkpointGranularity,
-      checkpointTimeAvailability)
-    val dataCube = new CubeOperations(cube, timeDimensionName, checkpointGranularity)
+      checkpointInterval)
+    val dataCube = new CubeOperations(cube)
 
     testOperation(getEventInput(sqlTimestamp), dataCube.extractDimensionsAggregations,
       getEventOutput(sqlTimestamp, millis), PreserverOrder)
@@ -111,9 +108,9 @@ class CubeMakerTest extends TestSuiteBase {
     val valuesMap3 = InputFieldsValues(Map("eventKey" -> "value3") ++ tsMap)
 
     Seq(Seq(
-      (DimensionValuesTime("cubeName",Seq(dimensionValueString1, dimensionValueTs), millis, "minute"), valuesMap1),
-      (DimensionValuesTime("cubeName",Seq(dimensionValueString2, dimensionValueTs), millis, "minute"), valuesMap2),
-      (DimensionValuesTime("cubeName",Seq(dimensionValueString3, dimensionValueTs), millis, "minute"), valuesMap3)
+      (DimensionValuesTime("cubeName", Seq(dimensionValueString1, dimensionValueTs)), valuesMap1),
+      (DimensionValuesTime("cubeName", Seq(dimensionValueString2, dimensionValueTs)), valuesMap2),
+      (DimensionValuesTime("cubeName", Seq(dimensionValueString3, dimensionValueTs)), valuesMap3)
     ))
   }
 }

--- a/aggregator/src/test/scala/com/stratio/sparkta/aggregator/CubeTest.scala
+++ b/aggregator/src/test/scala/com/stratio/sparkta/aggregator/CubeTest.scala
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2016 Stratio (http://stratio.com)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+  * Copyright (C) 2016 Stratio (http://stratio.com)
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 
 package com.stratio.sparkta.aggregator
 
@@ -31,7 +31,7 @@ import com.stratio.sparkta.sdk._
 @RunWith(classOf[JUnitRunner])
 class CubeTest extends TestSuiteBase {
 
-  test("aggregate") {
+  test("aggregate with time") {
 
     val PreserverOrder = true
     val defaultDimension = new DefaultField
@@ -40,43 +40,140 @@ class CubeTest extends TestSuiteBase {
     val checkpointGranularity = "minute"
     val eventGranularity = DateOperations.dateFromGranularity(DateTime.now(), "minute")
     val name = "cubeName"
+    val timeConfig = Option(TimeConfig(eventGranularity, checkpointGranularity))
+
+    val expiringDataConfig = ExpiringDataConfig(
+      checkpointGranularity, checkpointGranularity, checkpointTimeAvailability
+    )
 
     val cube = Cube(
       name,
       Seq(Dimension("dim1", "foo", "identity", defaultDimension)),
-      Seq(new CountOperator("count", Map()), new SumOperator("sum", Map("inputField" -> "n"))),
-      checkpointGranularity,
+      Seq(new CountOperator("count", Map()),new SumOperator("sum", Map("inputField" -> "n"))),
       checkpointInterval,
-      checkpointGranularity,
-      checkpointTimeAvailability)
+      Option(expiringDataConfig)
+    )
 
     testOperation(getInput, cube.aggregate, getOutput, PreserverOrder)
 
     def getInput: Seq[Seq[(DimensionValuesTime, InputFieldsValues)]] = Seq(Seq(
-      (DimensionValuesTime("testCube",Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "bar")),
-        eventGranularity, checkpointGranularity), InputFieldsValues(Map[String, JSerializable]("n" -> 4))),
-      (DimensionValuesTime("testCube",Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "bar")),
-        eventGranularity, checkpointGranularity), InputFieldsValues(Map[String, JSerializable]("n" -> 3))),
-      (DimensionValuesTime("testCube",Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "foo")),
-        eventGranularity, checkpointGranularity), InputFieldsValues(Map[String, JSerializable]("n" -> 3)))),
+      (DimensionValuesTime("testCube",
+        Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "bar")),
+        timeConfig
+      ),
+        InputFieldsValues(Map[String, JSerializable]("n" -> 4))),
+
+      (DimensionValuesTime("testCube",
+        Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "bar")),
+        timeConfig),
+        InputFieldsValues(Map[String, JSerializable]("n" -> 3))),
+
+      (DimensionValuesTime("testCube",
+        Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "foo")),
+        timeConfig),
+        InputFieldsValues(Map[String, JSerializable]("n" -> 3)))),
+
       Seq(
-        (DimensionValuesTime("testCube",Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "bar")),
-          eventGranularity, checkpointGranularity), InputFieldsValues(Map[String, JSerializable]("n" -> 4))),
-        (DimensionValuesTime("testCube",Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "bar")),
-          eventGranularity, checkpointGranularity), InputFieldsValues(Map[String, JSerializable]("n" -> 3))),
-        (DimensionValuesTime("testCube",Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "foo")),
-          eventGranularity, checkpointGranularity), InputFieldsValues(Map[String, JSerializable]("n" -> 3)))))
+        (DimensionValuesTime("testCube",
+          Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "bar")),
+          timeConfig),
+          InputFieldsValues(Map[String, JSerializable]("n" -> 4))),
+
+        (DimensionValuesTime("testCube",
+          Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "bar")),
+          timeConfig),
+          InputFieldsValues(Map[String, JSerializable]("n" -> 3))),
+
+        (DimensionValuesTime("testCube",
+          Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "foo")),
+          timeConfig),
+          InputFieldsValues(Map[String, JSerializable]("n" -> 3)))))
 
     def getOutput: Seq[Seq[(DimensionValuesTime, MeasuresValues)]] = Seq(
       Seq(
-        (DimensionValuesTime("testCube",Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension),
-          "bar")), eventGranularity, checkpointGranularity), MeasuresValues(Map("count" -> Some(2L), "sum" -> Some(7L)))),
-        (DimensionValuesTime("testCube",Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension),
-          "foo")), eventGranularity, checkpointGranularity), MeasuresValues(Map("count" -> Some(1L), "sum" -> Some(3L))))),
+        (DimensionValuesTime("testCube",
+          Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "bar")),
+          timeConfig),
+          MeasuresValues(Map("count" -> Some(2L), "sum" -> Some(7L)))),
+
+        (DimensionValuesTime("testCube",
+          Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "foo")),
+          timeConfig),
+          MeasuresValues(Map("count" -> Some(1L), "sum" -> Some(3L))))),
+
       Seq(
-        (DimensionValuesTime("testCube",Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension),
-          "bar")), eventGranularity, checkpointGranularity), MeasuresValues(Map("count" -> Some(4L), "sum" -> Some(14L)))),
-        (DimensionValuesTime("testCube",Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension),
-          "foo")), eventGranularity, checkpointGranularity), MeasuresValues(Map("count" -> Some(2L), "sum" -> Some(6L))))))
+        (DimensionValuesTime("testCube",
+          Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "bar")),
+          timeConfig),
+          MeasuresValues(Map("count" -> Some(4L), "sum" -> Some(14L)))),
+
+        (DimensionValuesTime("testCube",
+          Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "foo")),
+          timeConfig),
+          MeasuresValues(Map("count" -> Some(2L), "sum" -> Some(6L))))))
+  }
+
+  test("aggregate without time") {
+
+    val PreserverOrder = true
+    val defaultDimension = new DefaultField
+    val checkpointInterval = 10000
+    val name = "cubeName"
+
+
+    val cube = Cube(
+      name,
+      Seq(Dimension("dim1", "foo", "identity", defaultDimension)),
+      Seq(new CountOperator("count", Map()),new SumOperator("sum", Map("inputField" -> "n"))),
+      checkpointInterval
+    )
+
+    testOperation(getInput, cube.aggregate, getOutput, PreserverOrder)
+
+    def getInput: Seq[Seq[(DimensionValuesTime, InputFieldsValues)]] = Seq(Seq(
+      (DimensionValuesTime("testCube",
+        Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "bar"))
+      ),
+        InputFieldsValues(Map[String, JSerializable]("n" -> 4))),
+
+      (DimensionValuesTime("testCube",
+        Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "bar"))),
+        InputFieldsValues(Map[String, JSerializable]("n" -> 3))),
+
+      (DimensionValuesTime("testCube",
+        Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "foo"))),
+        InputFieldsValues(Map[String, JSerializable]("n" -> 3)))),
+
+      Seq(
+        (DimensionValuesTime("testCube",
+          Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "bar"))),
+          InputFieldsValues(Map[String, JSerializable]("n" -> 4))),
+
+        (DimensionValuesTime("testCube",
+          Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "bar"))),
+          InputFieldsValues(Map[String, JSerializable]("n" -> 3))),
+
+        (DimensionValuesTime("testCube",
+          Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "foo"))),
+          InputFieldsValues(Map[String, JSerializable]("n" -> 3)))))
+
+    def getOutput: Seq[Seq[(DimensionValuesTime, MeasuresValues)]] = Seq(
+      Seq(
+        (DimensionValuesTime("testCube",
+          Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "bar"))),
+          MeasuresValues(Map("count" -> Some(2L), "sum" -> Some(7L)))),
+
+        (DimensionValuesTime("testCube",
+          Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "foo"))),
+          MeasuresValues(Map("count" -> Some(1L), "sum" -> Some(3L))))),
+
+      Seq(
+        (DimensionValuesTime("testCube",
+          Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "bar"))),
+          MeasuresValues(Map("count" -> Some(4L), "sum" -> Some(14L)))),
+
+        (DimensionValuesTime("testCube",
+          Seq(DimensionValue(Dimension("dim1", "foo", "identity", defaultDimension), "foo"))),
+          MeasuresValues(Map("count" -> Some(2L), "sum" -> Some(6L))))))
   }
 }

--- a/driver/src/test/scala/com/stratio/sparkta/driver/test/factory/SchemaFactoryTest.scala
+++ b/driver/src/test/scala/com/stratio/sparkta/driver/test/factory/SchemaFactoryTest.scala
@@ -33,14 +33,17 @@ class SchemaFactoryTest extends FlatSpec with ShouldMatchers
 with MockitoSugar {
 
   "SchemaFactorySpec" should "return a list of schemas" in new CommonValues {
-    val cube = Cube(cubeName, Seq(dim1, dim2), Seq(op1),
-      "minute", checkpointInterval, checkpointGranularity, checkpointAvailable)
+    val cube = Cube(cubeName, Seq(dim1, dim2), Seq(op1), checkpointInterval,
+      Option(ExpiringDataConfig("minute", checkpointGranularity, checkpointInterval)))
     val cubes = Seq(cube)
-    val tableSchema = TableSchema("outputName", "cubeTest", StructType(Array(
-      StructField("dim1", StringType, false),
-      StructField("dim2", StringType, false),
-      StructField(checkpointGranularity, DateType, false),
-      StructField("op1", LongType, true))), "minute")
+    val tableSchema = TableSchema(
+      "outputName",
+      "cubeTest", StructType(Array(
+          StructField("dim1", StringType, false),
+          StructField("dim2", StringType, false),
+          StructField(checkpointGranularity, DateType, false),
+          StructField("op1", LongType, true))),
+      Option("minute"))
 
     val res = SchemaFactory.cubesOperatorsSchemas(cubes, configOptions)
 
@@ -103,17 +106,16 @@ with MockitoSugar {
     val cubeName = "cubeTest"
     val timestamp = 1L
     val defaultDimension = new DimensionTypeTest
-    val dimensionValuesT = DimensionValuesTime("testCube",Seq(DimensionValue(
-      Dimension("dim1", "eventKey", "identity", defaultDimension), "value1"),
-      DimensionValue(
-        Dimension("dim2", "eventKey", "identity", defaultDimension), "value2"),
-      DimensionValue(
-        Dimension("minute", "eventKey", "identity", defaultDimension), 1L)),
-      timestamp, checkpointGranularity)
-    val measures = Map("field" -> Some("value"))
+    val dimensionValuesT = DimensionValuesTime("testCube", Seq(DimensionValue(
+              Dimension("dim1", "eventKey", "identity", defaultDimension), "value1"),
+              DimensionValue(
+                Dimension("dim2", "eventKey", "identity", defaultDimension), "value2"),
+              DimensionValue(
+                Dimension("minute", "eventKey", "identity", defaultDimension), 1L)))
+    val measures = Map("field" -> Option("value"))
     val fixedDimensionsName = Seq("dim2")
-    val fixedDimensions = Some(Seq(("dim3", "value3")))
-    val fixedMeasure = Map("agg2" -> Some("2"))
+    val fixedDimensions = Option(Seq(("dim3", "value3")))
+    val fixedMeasure = Map("agg2" -> Option("2"))
   }
 
 }

--- a/plugins/output-cassandra/src/main/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraOutput.scala
+++ b/plugins/output-cassandra/src/main/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraOutput.scala
@@ -99,7 +99,7 @@ class CassandraOutput(keyName: String,
     persistDataFrame(stream)
   }
 
-  override def upsert(dataFrame: DataFrame, tableName: String, timeDimension: String): Unit = {
+  override def upsert(dataFrame: DataFrame, tableName: String, timeDimension: Option[String]): Unit = {
     val tableNameVersioned = getTableName(tableName.toLowerCase)
     write(dataFrame,tableNameVersioned)
   }

--- a/plugins/output-cassandra/src/test/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraDaoTest.scala
+++ b/plugins/output-cassandra/src/test/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraDaoTest.scala
@@ -30,10 +30,10 @@ class CassandraDaoTest extends FlatSpec with Matchers with MockitoSugar with Cas
 
   val cassandraConector = mock[CassandraConnector]
   val tableSchema = Seq(TableSchema("outputName", "myCube", StructType(Array(
-    StructField("dim1", StringType, false))), "minute"))
+      StructField("dim1", StringType, false))), Option("minute")))
   val structField = StructField("name", StringType, false)
   val schema: StructType = StructType(Array(structField))
-  val tableVersion = Some(1)
+  val tableVersion = Option(1)
 
   "getTableName" should "return the name of the table" in {
 
@@ -84,13 +84,13 @@ class CassandraDaoTest extends FlatSpec with Matchers with MockitoSugar with Cas
 
   "schemaToPkCcolumns" should "return the schema" in {
 
-    val res = schemaToPkCcolumns(schema, "cluster", false)
-    res should be (Some("(name text, PRIMARY KEY (name))"))
+    val res = schemaToPkCcolumns(schema, Option("cluster"), false)
+    res should be (Option("(name text, PRIMARY KEY (name))"))
   }
 
   "createTable" should "return true" in {
 
-    val res = createTable(cassandraConector, "tablename", schema, "cluster", false)
+    val res = createTable(cassandraConector, "tablename", schema, Option("cluster"), false)
     res should be (true)
   }
   override def keyspace: String = "sparkta"

--- a/plugins/output-cassandra/src/test/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraOutputTest.scala
+++ b/plugins/output-cassandra/src/test/scala/com/stratio/sparkta/plugin/output/cassandra/CassandraOutputTest.scala
@@ -34,7 +34,7 @@ import org.scalatest.{FlatSpec, Matchers}
 class CassandraOutputTest extends FlatSpec with Matchers with MockitoSugar with AnswerSugar {
 
   val s = "sum"
-  val operation = Some(Map(s ->(WriteOp.Inc, TypeOp.Int)))
+  val operation = Option(Map(s ->(WriteOp.Inc, TypeOp.Int)))
   val properties = Map(("connectionHost", "127.0.0.1"), ("connectionPort", "9042"))
 
   "getSparkConfiguration" should "return a Seq with the configuration" in {
@@ -47,23 +47,23 @@ class CassandraOutputTest extends FlatSpec with Matchers with MockitoSugar with 
   "doPersist" should "return nothing because DataFramWriter are imposible to mock since it is a final class" in {
 
     val tableSchema = Seq(TableSchema("outputName", "dim1", StructType(Array(
-      StructField("dim1", StringType, false))), "minute"))
+          StructField("dim1", StringType, false))), Option("minute")))
 
     val out =  spy(new CassandraOutput("key", None, properties, operation, Option(tableSchema)))
     val df: DataFrame = mock[DataFrame]
 
     doNothing().when(out).write(df,"tablename")
-    out.upsert(df,"tablename","minute")
+    out.upsert(df, "tablename", Option("minute"))
   }
 
   "setup" should "return X" in {
 
     val tableSchema = Seq(TableSchema("outputName", "dim1", StructType(Array(
-      StructField("dim1", StringType, false))), "minute"))
+          StructField("dim1", StringType, false))), Option("minute")))
 
     val cassandraConnector: CassandraConnector = mock[CassandraConnector]
 
-    val out =  new CassandraOutput("key", Some(1), properties, operation, Option(tableSchema)) {
+    val out =  new CassandraOutput("key", Option(1), properties, operation, Option(tableSchema)) {
       override val textIndexFields = Option(Array("test"))
       override def getCassandraConnector(): CassandraConnector = {
         cassandraConnector

--- a/plugins/output-csv/src/main/scala/com/stratio/sparkta/plugin/output/csv/CsvOutput.scala
+++ b/plugins/output-csv/src/main/scala/com/stratio/sparkta/plugin/output/csv/CsvOutput.scala
@@ -53,7 +53,7 @@ class CsvOutput(keyName: String,
 
   val dateGranularityFile = properties.getString("dateGranularityFile", "day")
 
-  override def upsert(dataFrame: DataFrame, tableName: String, timeDimension: String): Unit = {
+  override def upsert(dataFrame: DataFrame, tableName: String, timeDimension: Option[String]): Unit = {
     require(path.isDefined, "Destination path is required. You have to set 'path' on properties")
     val pathParsed = if (path.get.endsWith("/")) path.get else path.get + "/"
     val subPath = DateOperations.subPath(dateGranularityFile, datePattern)

--- a/plugins/output-csv/src/test/scala/com/stratio/sparkta/plugin/output/csv/CsvOutputTest.scala
+++ b/plugins/output-csv/src/test/scala/com/stratio/sparkta/plugin/output/csv/CsvOutputTest.scala
@@ -30,13 +30,13 @@ import org.scalatest.{FlatSpec, Matchers}
 @RunWith(classOf[JUnitRunner])
 class CsvOutputTest extends FlatSpec with Matchers with MockitoSugar {
   "CsvOutput" should "upsert a file" in {
-    val opTypes = Some(Map("sum" ->(WriteOp.Inc, TypeOp.Int)))
+    val opTypes = Option(Map("sum" ->(WriteOp.Inc, TypeOp.Int)))
     val out = spy(new CsvOutput("keyName", None, Map("path" -> "path"), opTypes, None))
     val dataframe = mock[DataFrame]
     implicit val savemock = mock[CsvSchemaRDD]
     doNothing().when(out).saveAction(any[String], meq(dataframe))
 
-    out.upsert(dataframe, "tableName", "")
+    out.upsert(dataframe, "tableName", Some(""))
 
     verify(out).saveAction(any[String], meq(dataframe))
   }

--- a/plugins/output-elasticsearch/src/main/scala/com/stratio/sparkta/plugin/output/elasticsearch/dao/ElasticSearchDAO.scala
+++ b/plugins/output-elasticsearch/src/main/scala/com/stratio/sparkta/plugin/output/elasticsearch/dao/ElasticSearchDAO.scala
@@ -48,15 +48,17 @@ trait ElasticSearchDAO {
 
   def mappingType: String
 
-  def getSparkConfig(timeName: String, idProvided: Boolean): Map[String, String] = {
+  def getSparkConfig(timeName: Option[String], idProvided: Boolean): Map[String, String] = {
     if (idProvided)
       Map("es.mapping.id" -> idField.getOrElse(Output.Id))
     else
       Map()
   } ++
     Map("es.nodes" -> httpNodes(0)._1, "es.port" -> httpNodes(0)._2.toString, "es.index.auto.create" -> "no") ++ {
-    if (timeName.isEmpty) Map()
-    else Map("es.mapping.timestamp" -> timeName)
+    timeName match {
+      case Some(timeNameValue) if !timeNameValue.isEmpty =>  Map("es.mapping.timestamp" -> timeNameValue)
+      case _ => Map()
+    }
   }
 
   def getDateTimeType(dateType: Option[String]): TypeOp = {

--- a/plugins/output-elasticsearch/src/test/scala/com/stratio/sparkta/plugin/output/elasticsearch/ElasticSearchOutputTest.scala
+++ b/plugins/output-elasticsearch/src/test/scala/com/stratio/sparkta/plugin/output/elasticsearch/ElasticSearchOutputTest.scala
@@ -64,7 +64,7 @@ class ElasticSearchOutputTest extends FlatSpec with ShouldMatchers {
     val tableName = "sparktaTable"
     val baseFields = Seq(StructField("string", StringType), StructField("int", IntegerType))
     val schema = StructType(baseFields)
-    val tableSchema = TableSchema("ES-out", tableName, schema, "timestamp")
+    val tableSchema = TableSchema("ES-out", tableName, schema, Option("timestamp"))
     val extraFields = Seq(StructField("id", StringType, false), StructField("timestamp", LongType, false))
     val expectedSchema = StructType(extraFields ++ baseFields)
     val expectedTableSchema =
@@ -73,7 +73,7 @@ class ElasticSearchOutputTest extends FlatSpec with ShouldMatchers {
       """[{"node":"localhost","httpPort":"9200","tcpPort":"9300"}]""".stripMargin),
       "dateType" -> "long",
       "clusterName" -> "elasticsearch")
-    override val output = new ElasticSearchOutput("ES-out", None, properties, None, bcSchema = Some(Seq(tableSchema)))
+    override val output = new ElasticSearchOutput("ES-out", None, properties, None, bcSchema = Option(Seq(tableSchema)))
     val dateField = StructField("timestamp", TimestampType, false)
     val expectedDateField = StructField("timestamp", LongType, false)
     val stringField = StructField("string", StringType)
@@ -95,7 +95,7 @@ class ElasticSearchOutputTest extends FlatSpec with ShouldMatchers {
       StructField("string", StringType),
       StructField("binary", BinaryType))
     val completeSchema = StructType(fields)
-    val completeTableSchema = TableSchema("elasticsearch", "table", completeSchema, "timestamp")
+    val completeTableSchema = TableSchema("elasticsearch", "table", completeSchema, Option("timestamp"))
     val definitions = Seq(
       "long".typed(FieldType.LongType),
       "double".typed(FieldType.DoubleType),
@@ -141,11 +141,11 @@ class ElasticSearchOutputTest extends FlatSpec with ShouldMatchers {
   }
 
   it should "return a correct date type" in new TestingValues {
-    val result = output.filterDateTypeMapping(dateField, "timestamp") should be (expectedDateField)
+    val result = output.filterDateTypeMapping(dateField, Option("timestamp")) should be (expectedDateField)
   }
 
   it should "return a correct type" in new TestingValues {
-    val result = output.filterDateTypeMapping(stringField, "timestamp") should be (expectedStringField)
+    val result = output.filterDateTypeMapping(stringField, Option("timestamp")) should be (expectedStringField)
   }
 
   it should "parse correct index name type" in new TestingValues{

--- a/plugins/output-elasticsearch/src/test/scala/com/stratio/sparkta/plugin/output/elasticsearch/dao/ElasticSearchDaoTest.scala
+++ b/plugins/output-elasticsearch/src/test/scala/com/stratio/sparkta/plugin/output/elasticsearch/dao/ElasticSearchDaoTest.scala
@@ -40,18 +40,18 @@ class ElasticSearchDAOTest extends FlatSpec with ShouldMatchers {
   }
 
   "ElasticSearchDao" should "return a valid configuration" in new ValuesMap {
-    dao.getSparkConfig("", false) should be(baseMap)
-    dao.getSparkConfig("", true) should be(expectedProvided)
-    dao.getSparkConfig("minutes", false) should be(expectedWithTs)
-    dao.getSparkConfig("minutes", true) should be(expectedProvidedWithTs)
+    dao.getSparkConfig(Option(""), false) should be(baseMap)
+    dao.getSparkConfig(Option(""), true) should be(expectedProvided)
+    dao.getSparkConfig(Option("minutes"), false) should be(expectedWithTs)
+    dao.getSparkConfig(Option("minutes"), true) should be(expectedProvidedWithTs)
   }
 
   it should "return a valid TypeOp from dateType" in new BaseValues {
     dao.getDateTimeType(None) should be(TypeOp.Long)
-    dao.getDateTimeType(Some("timestamp")) should be(TypeOp.Timestamp)
-    dao.getDateTimeType(Some("date")) should be(TypeOp.Date)
-    dao.getDateTimeType(Some("datetime")) should be(TypeOp.DateTime)
-    dao.getDateTimeType(Some("fake")) should be(TypeOp.String)
+    dao.getDateTimeType(Option("timestamp")) should be(TypeOp.Timestamp)
+    dao.getDateTimeType(Option("date")) should be(TypeOp.Date)
+    dao.getDateTimeType(Option("datetime")) should be(TypeOp.DateTime)
+    dao.getDateTimeType(Option("fake")) should be(TypeOp.String)
   }
 
   it should "test extra methods for coverage" in new BaseValues {

--- a/plugins/output-kafka/src/main/scala/com/stratio/sparkta/plugin/output/kafka/KafkaOutput.scala
+++ b/plugins/output-kafka/src/main/scala/com/stratio/sparkta/plugin/output/kafka/KafkaOutput.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.stratio.sparkta.plugin.output.kafka
 
 import java.io.{Serializable => JSerializable}
@@ -31,7 +32,7 @@ class KafkaOutput(keyName: String,
                   bcSchema: Option[Seq[TableSchema]])
   extends Output(keyName, version, properties, operationTypes, bcSchema) with KafkaProducer {
 
-  override def upsert(dataFrame: DataFrame, tableName: String, timeDimension: String): Unit = {
+  override def upsert(dataFrame: DataFrame, tableName: String, timeDimension: Option[String]): Unit = {
     dataFrame.toJSON.foreachPartition {
       messages => messages.foreach(message =>
         send(properties, tableName, message))

--- a/plugins/output-kafka/src/test/scala/KafkaProducerTest.scala
+++ b/plugins/output-kafka/src/test/scala/KafkaProducerTest.scala
@@ -26,10 +26,6 @@ import org.scalatest.junit.JUnitRunner
 
 import scala.util.Try
 
-/**
- * Created by eambrosio on 20/01/16.
- */
-
 @RunWith(classOf[JUnitRunner])
 class KafkaProducerTest extends FlatSpec with Matchers {
 

--- a/plugins/output-mongodb/src/main/scala/com/stratio/sparkta/plugin/output/mongodb/dao/MongoDbDAO.scala
+++ b/plugins/output-mongodb/src/main/scala/com/stratio/sparkta/plugin/output/mongodb/dao/MongoDbDAO.scala
@@ -87,7 +87,7 @@ trait MongoDbDAO extends Logging {
 
   protected def createPkTextIndex(mongoDatabase : MongoClient,
                                   collection : String,
-                                  timeDimension : String) : (Boolean, Boolean) = {
+                                  timeDimension : Option[String]) : (Boolean, Boolean) = {
     val textIndexCreated = if (textIndexFields.isDefined && language.isDefined) {
       if (textIndexFields.get.length > 0) {
         createTextIndex(mongoDatabase,
@@ -99,10 +99,13 @@ trait MongoDbDAO extends Logging {
       } else false
     } else false
 
-    if (!timeDimension.isEmpty) {
-      createIndex(mongoDatabase, collection, Output.Id + Output.Separator + timeDimension,
-        Map(Output.Id -> 1, timeDimension -> 1), true, true)
-    } else createIndex(mongoDatabase, collection, Output.Id, Map(Output.Id -> 1), true, true)
+    timeDimension match {
+      case Some(timeDimensionValue) if !timeDimensionValue.isEmpty =>
+        createIndex(mongoDatabase, collection, Output.Id + Output.Separator + timeDimension,
+          Map(Output.Id -> 1, timeDimensionValue -> 1), true, true)
+      case _ =>
+        createIndex(mongoDatabase, collection, Output.Id, Map(Output.Id -> 1), true, true)
+    }
 
     (!timeDimension.isEmpty, textIndexCreated)
   }

--- a/plugins/output-parquet/src/test/scala/com/stratio/sparkta/plugin/output/parquet/ParquetOutputIT.scala
+++ b/plugins/output-parquet/src/test/scala/com/stratio/sparkta/plugin/output/parquet/ParquetOutputIT.scala
@@ -77,7 +77,7 @@ class ParquetOutputIT extends FlatSpec with ShouldMatchers with BeforeAndAfterAl
   }
 
   "ParquetOutputIT" should "save a dataframe" in new WithEventData {
-    output.upsert(data, "person", "minute")
+    output.upsert(data, "person", Option("minute"))
     val read = sqlContext.read.parquet(tmpPath).toDF
     read.count should be(3)
     read should be eq (data)
@@ -85,7 +85,7 @@ class ParquetOutputIT extends FlatSpec with ShouldMatchers with BeforeAndAfterAl
   }
 
   it should "throw an exception when path is not present" in new WithWrongOutput {
-    an[Exception] should be thrownBy output.upsert(data, "person", "minute")
+    an[Exception] should be thrownBy output.upsert(data, "person", Option("minute"))
   }
 }
 

--- a/plugins/output-print/src/main/scala/com/stratio/sparkta/plugin/output/print/PrintOutput.scala
+++ b/plugins/output-print/src/main/scala/com/stratio/sparkta/plugin/output/print/PrintOutput.scala
@@ -28,7 +28,8 @@ import com.stratio.sparkta.sdk._
 
 /**
  * This output prints all AggregateOperations or DataFrames information on screen. Very useful to debug.
- * @param keyName
+  *
+  * @param keyName
  * @param properties
  * @param operationTypes
  * @param bcSchema
@@ -40,7 +41,7 @@ class PrintOutput(keyName: String,
                   bcSchema: Option[Seq[TableSchema]])
   extends Output(keyName, version, properties, operationTypes, bcSchema) with Logging {
 
-  override def upsert(dataFrame: DataFrame, tableName: String, timeDimension: String): Unit = {
+  override def upsert(dataFrame: DataFrame, tableName: String, timeDimension: Option[String]): Unit = {
     if (log.isDebugEnabled) {
       log.debug(s"> Table name       : $tableName")
       log.debug(s"> Version policy   : $version")
@@ -53,7 +54,16 @@ class PrintOutput(keyName: String,
   }
 
   override def upsert(metricOperations: Iterator[(DimensionValuesTime, MeasuresValues)]): Unit = {
-    metricOperations.foreach(metricOp =>
-      log.info(AggregateOperations.toString(metricOp._1, metricOp._2, metricOp._1.timeDimension, fixedDimensions)))
+    metricOperations.foreach(
+      metricOp => metricOp match {
+        case (dimensionValues, measuresValues) =>
+          val timeDimension = dimensionValues.timeConfig match {
+            case None => ""
+            case Some(timeConfig) => timeConfig.timeDimension
+          }
+          log.info(AggregateOperations.toString(dimensionValues, measuresValues, timeDimension, fixedDimensions))
+      }
+    )
+
   }
 }

--- a/plugins/output-solr/src/main/scala/com/stratio/sparkta/plugin/output/solr/SolrOutput.scala
+++ b/plugins/output-solr/src/main/scala/com/stratio/sparkta/plugin/output/solr/SolrOutput.scala
@@ -79,7 +79,7 @@ class SolrOutput(keyName: String,
     if (validConfiguration) persistDataFrame(stream)
     else log.info(SolrConfigurationError)
 
-  override def upsert(dataFrame: DataFrame, tableName: String, timeDimension: String): Unit = {
+  override def upsert(dataFrame: DataFrame, tableName: String, timeDimension: Option[String]): Unit = {
     val slrRelation = new SolrRelation(sqlContext, getConfig(connection, tableName), dataFrame)
     slrRelation.insert(dataFrame, true)
   }

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/ExpiringDataConfig.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/ExpiringDataConfig.scala
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016 Stratio (http://stratio.com)
+ * Copyright (C) 2015 Stratio (http://stratio.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,4 @@
 
 package com.stratio.sparkta.sdk
 
-case class DimensionValuesTime(cube: String,
-                               dimensionValues: Seq[DimensionValue],
-                               timeConfig: Option[TimeConfig] = None)
+case class ExpiringDataConfig(timeDimension: String, granularity: String, timeAvailability: Long)

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/TableSchema.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/TableSchema.scala
@@ -20,5 +20,5 @@ import java.io.Serializable
 
 import org.apache.spark.sql.types.StructType
 
-case class TableSchema(outputName: String, tableName: String, schema: StructType, timeDimension: String)
+case class TableSchema(outputName: String, tableName: String, schema: StructType, timeDimension: Option[String] = None)
   extends Serializable {}

--- a/sdk/src/main/scala/com/stratio/sparkta/sdk/TimeConfig.scala
+++ b/sdk/src/main/scala/com/stratio/sparkta/sdk/TimeConfig.scala
@@ -1,0 +1,20 @@
+/**
+  * Copyright (C) 2016 Stratio (http://stratio.com)
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package com.stratio.sparkta.sdk
+
+
+case class TimeConfig(eventTime: Long, timeDimension: String)

--- a/sdk/src/test/scala/com/stratio/sparkta/sdk/AggregateOperationsTest.scala
+++ b/sdk/src/test/scala/com/stratio/sparkta/sdk/AggregateOperationsTest.scala
@@ -33,17 +33,18 @@ class AggregateOperationsTest extends FlatSpec with ShouldMatchers {
     val timeDimension = "minute"
     val timestamp = 1L
     val defaultDimension = new DimensionTypeMock(Map())
-    val dimensionValuesT = DimensionValuesTime("testCube",Seq(DimensionValue(
-      Dimension("dim1", "eventKey", "identity", defaultDimension), "value1"),
-      DimensionValue(
-        Dimension("dim2", "eventKey", "identity", defaultDimension), "value2"),
-      DimensionValue(
-        Dimension("minute", "eventKey", "identity", defaultDimension), 1L)),
-      timestamp, timeDimension)
-    val measures = MeasuresValues(Map("field" -> Some("value")))
+    val dimensionValuesT = DimensionValuesTime(
+      "testCube",
+      Seq(
+        DimensionValue(Dimension("dim1", "eventKey", "identity", defaultDimension), "value1"),
+        DimensionValue(Dimension("dim2", "eventKey", "identity", defaultDimension), "value2"),
+        DimensionValue(Dimension("minute", "eventKey", "identity", defaultDimension), 1L)
+      ),
+      Option(TimeConfig(timestamp, timeDimension)))
+    val measures = MeasuresValues(Map("field" -> Option("value")))
     val fixedDimensionsName = Seq("dim2")
-    val fixedDimensions = Some(Seq(("dim3", "value3")))
-    val fixedMeasures = MeasuresValues(Map("agg2" -> Some("2")))
+    val fixedDimensions = Option(Seq(("dim3", "value3")))
+    val fixedMeasures = MeasuresValues(Map("agg2" -> Option("2")))
     val measureEmpty = MeasuresValues(Map())
   }
 
@@ -54,14 +55,14 @@ class AggregateOperationsTest extends FlatSpec with ShouldMatchers {
   }
 
   it should "return a correct toKeyRow tuple" in new CommonValues {
-    val expect = (Some("testCube"), Row("value1", "value2", "value3", new Timestamp(1L), "2", "value"))
+    val expect = (Option("testCube"), Row("value1", "value2", "value3", new Timestamp(1L), "2", "value"))
     val result = AggregateOperations.toKeyRow(
       dimensionValuesT, measures, fixedMeasures, fixedDimensions, false, TypeOp.Timestamp)
     result should be(expect)
   }
 
   it should "return a correct toKeyRow tuple without fixedMeasure" in new CommonValues {
-    val expect = (Some("testCube"), Row("value1", "value2", "value3", new Timestamp(1L), "value"))
+    val expect = (Option("testCube"), Row("value1", "value2", "value3", new Timestamp(1L), "value"))
     val result = AggregateOperations.toKeyRow(dimensionValuesT,
       measures,
       measureEmpty,
@@ -72,14 +73,14 @@ class AggregateOperationsTest extends FlatSpec with ShouldMatchers {
   }
 
   it should "return a correct toKeyRow tuple without fixedDimensions" in new CommonValues {
-    val expect = (Some("testCube"), Row("value1", "value2", new Timestamp(1L), "2", "value"))
+    val expect = (Option("testCube"), Row("value1", "value2", new Timestamp(1L), "2", "value"))
     val result = AggregateOperations.toKeyRow(
       dimensionValuesT, measures, fixedMeasures, None, false, TypeOp.Timestamp)
     result should be(expect)
   }
 
   it should "return a correct toKeyRow tuple without fixedDimensions and fixedMeasure" in new CommonValues {
-    val expect = (Some("testCube"), Row("value1", "value2", new Timestamp(1L), "value"))
+    val expect = (Option("testCube"), Row("value1", "value2", new Timestamp(1L), "value"))
     val result = AggregateOperations.toKeyRow(
       dimensionValuesT, measures, measureEmpty, None, false, TypeOp.Timestamp)
     result should be(expect)
@@ -87,7 +88,7 @@ class AggregateOperationsTest extends FlatSpec with ShouldMatchers {
 
   it should "return a correct toKeyRow tuple without measures and  fixedDimensions and fixedMeasure" in
     new CommonValues {
-      val expect = (Some("testCube"), Row("value1", "value2", new Timestamp(1L)))
+      val expect = (Option("testCube"), Row("value1", "value2", new Timestamp(1L)))
       val result = AggregateOperations.toKeyRow(dimensionValuesT,
         measureEmpty,
         measureEmpty,
@@ -100,14 +101,18 @@ class AggregateOperationsTest extends FlatSpec with ShouldMatchers {
   it should "return a correct toKeyRow tuple without dimensions and aggregations and  fixedDimensions and " +
     "fixedMeasure" in
     new CommonValues {
-      val expect = (Some("testCube"), Row(new Timestamp(1L)))
+      val expect = (Option("testCube"), Row(new Timestamp(1L)))
+
       val result =
-        AggregateOperations.toKeyRow(DimensionValuesTime("testCube",Seq(), timestamp, timeDimension),
-          measureEmpty,
-          measureEmpty,
-          None,
-          false,
-          TypeOp.Timestamp)
+        AggregateOperations
+          .toKeyRow(
+            DimensionValuesTime("testCube", Seq(), Option(TimeConfig(timestamp, timeDimension))),
+            measureEmpty,
+            measureEmpty,
+            None,
+            false,
+            TypeOp.Timestamp)
+
       result should be(expect)
     }
 

--- a/sdk/src/test/scala/com/stratio/sparkta/sdk/OutputTest.scala
+++ b/sdk/src/test/scala/com/stratio/sparkta/sdk/OutputTest.scala
@@ -34,38 +34,36 @@ class OutputTest extends WordSpec with Matchers {
     val tableName = "table"
     val timestamp = 1L
     val defaultDimension = new DimensionTypeMock(Map())
-    val dimensionValuesT = DimensionValuesTime("testCube",Seq(DimensionValue(
-      Dimension("dim1", "eventKey", "identity", defaultDimension), "value1"),
-      DimensionValue(
-        Dimension("dim2", "eventKey", "identity", defaultDimension), "value2"),
-      DimensionValue(
-        Dimension("minute", "eventKey", "identity", defaultDimension), 1L)),
-      timestamp, timeDimension)
+    val dimensionValuesT = DimensionValuesTime("testCube", Seq(DimensionValue(
+              Dimension("dim1", "eventKey", "identity", defaultDimension), "value1"),
+              DimensionValue(
+                Dimension("dim2", "eventKey", "identity", defaultDimension), "value2"),
+              DimensionValue(
+                Dimension("minute", "eventKey", "identity", defaultDimension), 1L)))
 
-    val dimensionValuesTFixed = DimensionValuesTime("testCube",Seq(DimensionValue(
-      Dimension("dim1", "eventKey", "identity", defaultDimension), "value1"),
-      DimensionValue(
-        Dimension("minute", "eventKey", "identity", defaultDimension), 1L)),
-      timestamp, timeDimension)
+    val dimensionValuesTFixed = DimensionValuesTime("testCube", Seq(DimensionValue(
+              Dimension("dim1", "eventKey", "identity", defaultDimension), "value1"),
+              DimensionValue(
+                Dimension("minute", "eventKey", "identity", defaultDimension), 1L)))
 
     val tableSchema = TableSchema("outputName", "myCube", StructType(Array(
-      StructField("dim1", StringType, false),
-      StructField("dim2", StringType, false),
-      StructField("minute", DateType, false),
-      StructField("op1", LongType, true))), "minute")
+          StructField("dim1", StringType, false),
+          StructField("dim2", StringType, false),
+          StructField("minute", DateType, false),
+          StructField("op1", LongType, true))), Option("minute"))
     val outputName = "outputName"
 
     val output = new OutputMock(outputName,
       None,
       Map(),
-      Some(Map("op1" ->(WriteOp.Set, TypeOp.Long))),
-      Some(Seq(tableSchema)))
+      Option(Map("op1" ->(WriteOp.Set, TypeOp.Long))),
+      Option(Seq(tableSchema)))
 
     val outputOperation = new OutputMock(outputName,
       None,
       Map(),
-      Some(Map("op1" ->(WriteOp.Inc, TypeOp.Long))),
-      Some(Seq(tableSchema)))
+      Option(Map("op1" ->(WriteOp.Inc, TypeOp.Long))),
+      Option(Seq(tableSchema)))
 
     val outputProps = new OutputMock(outputName,
       None,
@@ -74,15 +72,15 @@ class OutputTest extends WordSpec with Matchers {
         "fixedMeasure" -> "op2:1",
         "isAutoCalculateId" -> "true"
       ),
-      Some(Map("op1" ->(WriteOp.Set, TypeOp.Long))),
-      Some(Seq(tableSchema)))
+      Option(Map("op1" ->(WriteOp.Set, TypeOp.Long))),
+      Option(Seq(tableSchema)))
 
 
     val outputVersioned = new OutputMock(outputName,
       Option(1),
       Map(),
-      Some(Map("op1" ->(WriteOp.Set, TypeOp.Long))),
-      Some(Seq(tableSchema)))
+      Option(Map("op1" ->(WriteOp.Set, TypeOp.Long))),
+      Option(Seq(tableSchema)))
 
   }
 
@@ -131,7 +129,7 @@ class OutputTest extends WordSpec with Matchers {
     }
 
     "with fixed measures must be " in new CommonValues {
-      val expected = MeasuresValues(Map("op2" -> Some("1")))
+      val expected = MeasuresValues(Map("op2" -> Option("1")))
       val result = outputProps.fixedMeasures
       result should be(expected)
     }
@@ -153,29 +151,30 @@ class OutputTest extends WordSpec with Matchers {
         StructField("dim1", StringType, false),
         StructField("dim2", StringType, false),
         StructField("minute", TimestampType, false),
-        StructField("op1", LongType, true))), "minute")
+        StructField("op1", LongType, true))), Option("minute"))
+
       val result = output.getTableSchemaFixedId(tableSchema)
       result should be(expected)
     }
 
     "the correct table schema according to the properties must be " in new CommonValues {
       val expected = TableSchema("outputName", "myCube", StructType(Array(
-        StructField("id", StringType, false),
-        StructField("dim1", StringType, false),
-        StructField("dim2", StringType, false),
-        StructField("minute", TimestampType, false),
-        StructField("op1", LongType, true))), "minute")
+              StructField("id", StringType, false),
+              StructField("dim1", StringType, false),
+              StructField("dim2", StringType, false),
+              StructField("minute", TimestampType, false),
+              StructField("op1", LongType, true))), Option("minute"))
       val result = outputProps.getTableSchemaFixedId(tableSchema)
       result should be(expected)
     }
 
     "the correct table schema according to the properties with fixed dimension must be " in new CommonValues {
       val expected = TableSchema("outputName", "myCube", StructType(Array(
-        StructField("id", StringType, false),
-        StructField("dim1", StringType, false),
-        StructField("dim2", StringType, false),
-        StructField("minute", TimestampType, false),
-        StructField("op1", LongType, true))), "minute")
+              StructField("id", StringType, false),
+              StructField("dim1", StringType, false),
+              StructField("dim2", StringType, false),
+              StructField("minute", TimestampType, false),
+              StructField("op1", LongType, true))), Option("minute"))
       val result = outputProps.getTableSchemaFixedId(tableSchema)
       result should be(expected)
     }
@@ -187,7 +186,7 @@ class OutputTest extends WordSpec with Matchers {
     }
 
     "the fixed dimensions according to the properties must be " in new CommonValues {
-      val expected = Some(Seq(("dim2", "value2")))
+      val expected = Option(Seq(("dim2", "value2")))
       val result = outputProps.getFixedDimensions(dimensionValuesT)
       result should be(expected)
     }

--- a/sdk/src/test/scala/com/stratio/sparkta/sdk/TableSchemaTest.scala
+++ b/sdk/src/test/scala/com/stratio/sparkta/sdk/TableSchemaTest.scala
@@ -27,10 +27,10 @@ class TableSchemaTest extends WordSpec with Matchers {
   "TableSchema" should {
 
     val tableSchema = TableSchema("outputName", "myCube", StructType(Array(
-      StructField("dim1", StringType, false))), "minute")
+          StructField("dim1", StringType, false))), Some("minute"))
 
     "toString must be " in {
-      val expected = "TableSchema(outputName,myCube,StructType(StructField(dim1,StringType,false)),minute)"
+      val expected = "TableSchema(outputName,myCube,StructType(StructField(dim1,StringType,false)),Some(minute))"
       val result = tableSchema.toString
       result should be(expected)
     }

--- a/test-at/src/test/resources/policies/ISocket-OCassandra-operators.json
+++ b/test-at/src/test/resources/policies/ISocket-OCassandra-operators.json
@@ -8,15 +8,15 @@
     "path": ""
   },
   "input":
-    {
-      "name": "in-socket",
-      "type": "Socket",
-      "configuration": {
-        "hostname": "localhost",
-        "port": "10666"
-      }
+  {
+    "name": "in-socket",
+    "type": "Socket",
+    "configuration": {
+      "hostname": "localhost",
+      "port": "10666"
     }
-  ,
+  }
+,
   "transformations": [
     {
       "name": "morphline-parser",
@@ -66,9 +66,124 @@
   ],
   "cubes": [
     {
-      "name": "testCube",
+      "name": "testCubeWithTime",
       "checkpointConfig": {
         "timeDimension": "minute",
+        "granularity": "minute",
+        "interval": 100000,
+        "timeAvailability": 90000
+      },
+      "dimensions": [
+        {
+          "name": "product",
+          "field": "product"
+        }
+      ],
+      "operators": [
+        {
+          "name": "avg_price",
+          "type": "Avg",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "count_price",
+          "type": "Count",
+          "configuration": {}
+        },
+        {
+          "name": "first_price",
+          "type": "FirstValue",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "fulltext_price",
+          "type": "FullText",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "last_price",
+          "type": "LastValue",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "max_price",
+          "type": "Max",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "median_price",
+          "type": "Median",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "min_price",
+          "type": "Min",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "range_price",
+          "type": "Range",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "stddev_price",
+          "type": "Stddev",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "sum_price",
+          "type": "Sum",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "variance_price",
+          "type": "Variance",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "entitycount_text",
+          "type": "EntityCount",
+          "configuration": {
+            "inputField": "text",
+            "split": " "
+          }
+        },
+        {
+          "name": "totalentity_text",
+          "type": "TotalEntityCount",
+          "configuration": {
+            "inputField": "text",
+            "split": " "
+          }
+        }
+      ]
+    },
+    {
+      "name": "testCubeWithoutTime",
+      "checkpointConfig": {
+        "timeDimension": "none",
         "granularity": "minute",
         "interval": 100000,
         "timeAvailability": 90000

--- a/test-at/src/test/resources/policies/ISocket-OElasticsearch-operators.json
+++ b/test-at/src/test/resources/policies/ISocket-OElasticsearch-operators.json
@@ -67,9 +67,138 @@
   ],
   "cubes": [
     {
-      "name": "testCube",
+      "name": "testCubeWithTime",
       "checkpointConfig": {
         "timeDimension": "minute",
+        "granularity": "minute",
+        "interval": 100000,
+        "timeAvailability": 90000
+      },
+      "dimensions": [
+        {
+          "name": "product",
+          "field": "product"
+        }
+      ],
+      "operators": [
+        {
+          "name": "acc_price",
+          "type": "Accumulator",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "avg_price",
+          "type": "Avg",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "count_price",
+          "type": "Count",
+          "configuration": {}
+        },
+        {
+          "name": "first_price",
+          "type": "FirstValue",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "fulltext_price",
+          "type": "FullText",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "mode_price",
+          "type": "Mode",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "last_price",
+          "type": "LastValue",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "max_price",
+          "type": "Max",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "median_price",
+          "type": "Median",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "min_price",
+          "type": "Min",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "range_price",
+          "type": "Range",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "stddev_price",
+          "type": "Stddev",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "sum_price",
+          "type": "Sum",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "variance_price",
+          "type": "Variance",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "entityCount_text",
+          "type": "EntityCount",
+          "configuration": {
+            "inputField": "text",
+            "split": " "
+          }
+        },
+        {
+          "name": "totalEntity_text",
+          "type": "TotalEntityCount",
+          "configuration": {
+            "inputField": "text",
+            "split": " "
+          }
+        }
+      ]
+    },
+    {
+      "name": "testCubeWithoutTime",
+      "checkpointConfig": {
+        "timeDimension": "none",
         "granularity": "minute",
         "interval": 100000,
         "timeAvailability": 90000

--- a/test-at/src/test/resources/policies/ISocket-OMongo-operators.json
+++ b/test-at/src/test/resources/policies/ISocket-OMongo-operators.json
@@ -67,9 +67,138 @@
   ],
   "cubes": [
     {
-      "name": "testCube",
+      "name": "testCubeWithTime",
       "checkpointConfig": {
         "timeDimension": "minute",
+        "granularity": "minute",
+        "interval": 100000,
+        "timeAvailability": 90000
+      },
+      "dimensions": [
+        {
+          "name": "product",
+          "field": "product"
+        }
+      ],
+      "operators": [
+        {
+          "name": "acc_price",
+          "type": "Accumulator",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "avg_price",
+          "type": "Avg",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "mode_price",
+          "type": "Mode",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "count_price",
+          "type": "Count",
+          "configuration": {}
+        },
+        {
+          "name": "first_price",
+          "type": "FirstValue",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "fulltext_price",
+          "type": "FullText",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "last_price",
+          "type": "LastValue",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "max_price",
+          "type": "Max",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "median_price",
+          "type": "Median",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "min_price",
+          "type": "Min",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "range_price",
+          "type": "Range",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "stddev_price",
+          "type": "Stddev",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "sum_price",
+          "type": "Sum",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "variance_price",
+          "type": "Variance",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "totalEntity_text",
+          "type": "TotalEntityCount",
+          "configuration": {
+            "inputField": "text",
+            "split": " "
+          }
+        },
+        {
+          "name": "entityCount_text",
+          "type": "EntityCount",
+          "configuration": {
+            "inputField": "text",
+            "split": " "
+          }
+        }
+      ]
+    },
+    {
+      "name": "testCubeWithoutTime",
+      "checkpointConfig": {
+        "timeDimension": "none",
         "granularity": "minute",
         "interval": 100000,
         "timeAvailability": 90000

--- a/test-at/src/test/resources/policies/ISocket-OParquet-operators.json
+++ b/test-at/src/test/resources/policies/ISocket-OParquet-operators.json
@@ -56,9 +56,138 @@
   ],
   "cubes": [
     {
-      "name": "testCube",
+      "name": "testCubeWithTime",
       "checkpointConfig": {
         "timeDimension": "minute",
+        "granularity": "minute",
+        "interval": 100000,
+        "timeAvailability": 90000
+      },
+      "dimensions": [
+        {
+          "name": "product",
+          "field": "product"
+        }
+      ],
+      "operators": [
+        {
+          "name": "acc_price",
+          "type": "Accumulator",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "avg_price",
+          "type": "Avg",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "count_price",
+          "type": "Count",
+          "configuration": {}
+        },
+        {
+          "name": "first_price",
+          "type": "FirstValue",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "fulltext_price",
+          "type": "FullText",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "last_price",
+          "type": "LastValue",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "max_price",
+          "type": "Max",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "median_price",
+          "type": "Median",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "min_price",
+          "type": "Min",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "range_price",
+          "type": "Range",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "stddev_price",
+          "type": "Stddev",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "sum_price",
+          "type": "Sum",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "variance_price",
+          "type": "Variance",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "mode_price",
+          "type": "Mode",
+          "configuration": {
+            "inputField": "price"
+          }
+        },
+        {
+          "name": "entityCount_text",
+          "type": "EntityCount",
+          "configuration": {
+            "inputField": "text",
+            "split": " "
+          }
+        },
+        {
+          "name": "totalEntity_text",
+          "type": "TotalEntityCount",
+          "configuration": {
+            "inputField": "text",
+            "split": " "
+          }
+        }
+      ]
+    },
+    {
+      "name": "testCubeWithoutTime",
+      "checkpointConfig": {
+        "timeDimension": "none",
         "granularity": "minute",
         "interval": 100000,
         "timeAvailability": 90000

--- a/test-at/src/test/scala/com/stratio/sparkta/testat/outputs/ISocketOCassandraOperatorsIT.scala
+++ b/test-at/src/test/scala/com/stratio/sparkta/testat/outputs/ISocketOCassandraOperatorsIT.scala
@@ -29,12 +29,12 @@ import scala.collection.JavaConversions._
 import scala.reflect.ClassTag
 
 /**
- * Acceptance test:
- * [Input]: Socket.
- * [Output]: Cassandra.
- * [Operators]: avg, count, firsValue, fullText, lastValue, max,
- * median, min, range, stddev, sum, variance.
- */
+  * Acceptance test:
+  * [Input]: Socket.
+  * [Output]: Cassandra.
+  * [Operators]: avg, count, firsValue, fullText, lastValue, max,
+  * median, min, range, stddev, sum, variance.
+  */
 @RunWith(classOf[JUnitRunner])
 class ISocketOCassandraOperatorsIT extends SparktaATSuite {
 
@@ -49,13 +49,15 @@ class ISocketOCassandraOperatorsIT extends SparktaATSuite {
   "Sparkta" should {
     "starts and executes a policy that reads from a socket and writes in cassandra" in {
       sparktaRunner
-      checkData
+      checkData("testCubeWithTime_v1")
+      checkData("testCubeWithoutTime_v1")
     }
 
-    def checkData: Unit = {
+    def checkData(tableName: String): Unit = {
+
       session = cluster.connect("sparkta")
 
-      val resultProductA: ResultSet = session.execute("select * from testCube_v1 where product = 'producta'")
+      val resultProductA: ResultSet = session.execute(s"select * from $tableName where product = 'producta'")
       val rowProductA = resultProductA.iterator().next()
 
       rowProductA.getDouble("avg_price") should be(639.0d)
@@ -74,7 +76,7 @@ class ISocketOCassandraOperatorsIT extends SparktaATSuite {
       counts should be(Map("hola" -> new lang.Long(16), "holo" -> new lang.Long(8)))
       rowProductA.getInt("totalentity_text") should be(24)
 
-      val resultProductB: ResultSet = session.execute("select * from testCube_v1 where product = 'productb'")
+      val resultProductB: ResultSet = session.execute(s"select * from $tableName where product = 'productb'")
       val rowProductB = resultProductB.iterator().next()
 
       rowProductB.getDouble("avg_price") should be(758.25d)

--- a/test-at/src/test/scala/com/stratio/sparkta/testat/outputs/ISocketOElasticsearchOperatorsIT.scala
+++ b/test-at/src/test/scala/com/stratio/sparkta/testat/outputs/ISocketOElasticsearchOperatorsIT.scala
@@ -49,11 +49,12 @@ class ISocketOElasticsearchOperatorsIT extends SparktaATSuite {
   "Sparkta" should {
     "starts and executes a policy that reads from a socket and writes in Elasticsearch" in {
       sparktaRunner
-      checkData
+      checkData("testcubewithtime")
+      checkData("testcubewithouttime")
     }
 
-    def checkData: Unit = {
-      val productA = getData("producta")
+    def checkData(tableName: String): Unit = {
+      val productA = getData("producta", tableName)
       productA("acc_price") should be(
         Seq("10", "500", "1000", "500", "1000", "500", "1002", "600"))
       productA("avg_price") should be(639.0d)
@@ -71,7 +72,7 @@ class ISocketOElasticsearchOperatorsIT extends SparktaATSuite {
       productA("entityCount_text") should be(Map("hola" -> 16L, "holo" -> 8L))
       productA("totalEntity_text") should be(24)
 
-      val productB = getData("productb")
+      val productB = getData("productb", tableName)
       productB("acc_price") should be(
         Seq("15", "1000", "1000", "1000", "1000", "1000", "1001", "50"))
       productB("avg_price") should be(758.25d)
@@ -90,10 +91,10 @@ class ISocketOElasticsearchOperatorsIT extends SparktaATSuite {
       productB("totalEntity_text") should be(24)
     }
 
-    def getData(productName: String): Map[String, Any] = {
+    def getData(productName: String, tableName: String): Map[String, Any] = {
       val pipeline: HttpRequest => Future[HttpResponse] = sendReceive
       val productArequest: Future[HttpResponse] =
-        pipeline(Get(s"http://$Localhost:9200/testcube/day_v1/_search?q=product:$productName"))
+        pipeline(Get(s"http://$Localhost:9200/$tableName/day_v1/_search?q=product:$productName"))
       val response: HttpResponse = Await.result(productArequest, Timeout(5.seconds).duration)
       JSON.globalNumberParser = { input: String => input.toDouble }
       val json = JSON.parseFull(response.entity.data.asString)

--- a/test-at/src/test/scala/com/stratio/sparkta/testat/outputs/ISocketOMongoOperatorsIT.scala
+++ b/test-at/src/test/scala/com/stratio/sparkta/testat/outputs/ISocketOMongoOperatorsIT.scala
@@ -45,11 +45,12 @@ class ISocketOMongoOperatorsIT extends MongoEmbedDatabase with SparktaATSuite {
   "Sparkta" should {
     "starts and executes a policy that reads from a socket and writes in mongodb" in {
       sparktaRunner
-      checkMongoData
+      checkMongoData("testCubeWithTime")
+      checkMongoData("testCubeWithoutTime")
     }
 
-    def checkMongoData(): Unit = {
-      val mongoColl: MongoCollection = mongoConnection("csvtest")("testCube")
+    def checkMongoData(tableName: String): Unit = {
+      val mongoColl: MongoCollection = mongoConnection("csvtest")(tableName)
       mongoColl.size should be(2)
 
       val productA = mongoColl.find(new BasicDBObject("product", "producta")).next()

--- a/test-at/src/test/scala/com/stratio/sparkta/testat/outputs/ISocketOParquetOperatorsIT.scala
+++ b/test-at/src/test/scala/com/stratio/sparkta/testat/outputs/ISocketOParquetOperatorsIT.scala
@@ -44,14 +44,15 @@ class ISocketOParquetOperatorsIT extends SparktaATSuite {
   "Sparkta" should {
     "starts and executes a policy that reads from a socket and writes in parquet" in {
       sparktaRunner
-      checkData
+      checkData("testCubeWithTime_v1")
+      checkData("testCubeWithoutTime_v1")
     }
 
     // scalastyle:off
-    def checkData(): Unit = {
+    def checkData(cubeName: String): Unit = {
       val sc = new SparkContext(s"local[$NumExecutors]", "ISocketOParquet-operators")
       val sqc = new SQLContext(sc)
-      val df = sqc.read.parquet(parquetPath).toDF
+      val df = sqc.read.parquet(parquetPath + s"/$cubeName").toDF
 
       val mapValues = df.map(row => Map(
         "product" -> row.getString(0),


### PR DESCRIPTION
Now we don't depend of the time to aggregate data. 

##### How to aggregate without time
To do it you have to specify it in the policy, in the "timeDimension" field you have to put "none
  ```
   "cubes": [
    {
      "name": "testCube",
      "checkpointConfig": {
        "timeDimension": "none",
        "granularity": "minute",
        "interval": 30000,
        "timeAvailability": 60000
      }
```

##### Test 
All passed. 
Test-at updated